### PR TITLE
Update links after repo transfer to metabrainz

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Further high quality contributions are welcomed from all Picard users wanting to
 
 If you want to contribute corrections or new material to this documentation project, there are a few different ways to submit your contributions.
 
-- If you are comfortable developing ReStructuredText format files, and are familiar with [Pull Requests](https://github.com/rdswift/picard-docs/pulls) on GitHub, you can submit a pull request with the changes to the documentation source files. This is the preferred method, because it provides a clear way for the changes to be reviewed and discussed.
+- If you are comfortable developing ReStructuredText format files, and are familiar with [Pull Requests](https://github.com/metabrainz/picard-docs/pulls) on GitHub, you can submit a pull request with the changes to the documentation source files. This is the preferred method, because it provides a clear way for the changes to be reviewed and discussed.
 
-- If you are not so comfortable developing ReStructuredText format files or preparing GitHub pull requests, you can create an [Issue](https://github.com/rdswift/picard-docs/issues) requesting the change (if the issue does not already exist) and attach your suggestions to it, either as an attached text file or within the discussion comments on the Issue. This way, someone can convert your suggestions into the appropriate (\*.rst) file changes and submit a pull request with the changes on your behalf.
+- If you are not so comfortable developing ReStructuredText format files or preparing GitHub pull requests, you can create a [ticket](https://tickets.metabrainz.org/issues/?filter=12025) under the Picard project (Documentation component) requesting the change (if the issue does not already exist) and attach your suggestions to it, either as an attached text file or within the discussion comments on the Issue. This way, someone can convert your suggestions into the appropriate (\*.rst) file changes and submit a pull request with the changes on your behalf.
 
 - You can also provide your suggestions on the Community Discussion Forum, or via email to the editor of the MusicBrainz Picard documentation project through their [account profile page](https://musicbrainz.org/user/rdswift) on [MusicBrainz](https://musicbrainz.org/).
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This project was created with the intent of eventually developing a comprehensiv
 user manual for [MusicBrainz Picard](https://picard.musicbrainz.org), a full-featured,
 cross-platform music file tagging system using metadata from [MusicBrainz](https://musicbrainz.org).
 
-This project is not intended to replace the documentation on the Picard website, but to augment
-it with additional detail and a structured approach.
-
 This documentation project is open source and provided under CC0 1.0. To view a copy of this license,
 visit [https://creativecommons.org/publicdomain/zero/1.0](https://creativecommons.org/publicdomain/zero/1.0).
 
@@ -26,7 +23,7 @@ documentation further will be most appreciated - and even if you cannot improve 
 if you can create or maintain translations into other languages, that would be of great benefit.
 
 If you notice an error in the documentation or have additional or updated material to contribute,
-please raise an issue in the [issue tracker](https://github.com/rdswift/picard-docs/issues).
-[Pull Requests](https://github.com/rdswift/picard-docs/pulls) to address outstanding issues are also
-appreciated.  Please see [CONTRIBUTING.md](https://github.com/rdswift/picard-docs/blob/master/.github/CONTRIBUTING.md)
+please create a [ticket](https://tickets.metabrainz.org/issues/?filter=12025) under the Picard project (Documentation component).
+[Pull Requests](https://github.com/metabrainz/picard-docs/pulls) to address outstanding issues are also
+appreciated.  Please see [CONTRIBUTING.md](https://github.com/metabrainz/picard-docs/blob/master/.github/CONTRIBUTING.md)
 for more information and additional ways to contribute.

--- a/about_picard/contributing.rst
+++ b/about_picard/contributing.rst
@@ -15,13 +15,12 @@ documentation further will be most appreciated.  Even if you cannot improve the 
 if you can create or maintain translations into other languages, that would be of great benefit.
 
 If you notice an error in the documentation or have additional material to contribute, please
-`raise an issue <https://github.com/rdswift/picard-docs/issues>`_ on the `documentation project
-on GitHub <https://github.com/rdswift/picard-docs/>`_.  `Pull Requests
-<https://github.com/rdswift/picard-docs/pulls>`_ to address outstanding issues are also
-appreciated.
+create a `ticket <https://tickets.metabrainz.org/issues/?filter=12025>`_  under the Picard
+project (Documentation component).  `Pull Requests <https://github.com/metabrainz/picard-docs/pulls>`_
+to address outstanding issues are also appreciated.
 
 .. seealso::
 
    `Contributing to MusicBrainz Picard <https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md>`_ /
    `Picard Translations <https://github.com/metabrainz/picard/blob/master/po/README.md>`_ /
-   `Contributing to the Documentation <https://github.com/rdswift/picard-docs/blob/master/.github/CONTRIBUTING.md>`_
+   `Contributing to the Documentation <https://github.com/metabrainz/picard-docs/blob/master/.github/CONTRIBUTING.md>`_

--- a/conf.py
+++ b/conf.py
@@ -212,9 +212,9 @@ notfound_template = 'custom_404.html'
 notfound_title = 'Page Not Found'
 notfound_text_1 = "We're sorry but we are unable to find the requested page. Please use the table " \
     + "of contents or the search box in the left-hand sidebar to locate your topic."
-notfound_text_2 = "If you believe that you have received this message in error, please report it on " \
-    + "the <a href='https://github.com/rdswift/picard-docs/issues/new/choose' " \
-    + "target='_blank'>documentation project site</a>.  Thanks."
+notfound_text_2 = "If you believe that you have received this message in error, please report it in " \
+    + "a <a href='https://tickets.metabrainz.org/issues/?filter=12025' target='_blank'>ticket</a> " \
+    + "under the Picard project (Documentation component).  Thanks."
 notfound_script = r'''
 <script>
     var target_language = 'en';

--- a/not_found.rst
+++ b/not_found.rst
@@ -8,5 +8,6 @@ Page Not Found
 We're sorry but we are unable to find the requested page.  Please use the table of contents or
 the search box in the left-hand sidebar to locate your topic.
 
-If you believe that you have received this message in error, please report it on the `documentation
-project site <https://github.com/rdswift/picard-docs/issues/new/choose>`_.  Thanks.
+If you believe that you have received this message in error, please report it in a
+`ticket <https://tickets.metabrainz.org/issues/?filter=12025>`_ under the Picard project
+(Documentation component).  Thanks.


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The repo was transferred from `rdswift` to `metabrainz` but the links still pointed to the `rdswift` repo.

### Description of the Change

Update the links from the `rdswift` repo to point to the `metabrainz` repo.

### Additional Action Required

Update translation files.
