### PR TITLE
Add missing commas in $slice() examples

### DIFF
--- a/functions/func_slice.rst
+++ b/functions/func_slice.rst
@@ -5,7 +5,7 @@
 $slice
 ======
 
-| Usage: **$slice(name,start,end[,separator])**
+| Usage: **$slice(name,start[,end[,separator]])**
 | Category: multi-value
 | Implemented: Picard 2.3
 
@@ -23,7 +23,7 @@ and the number of elements in the list respectively.
 
 A typical use might be to create a multi-value variable with all artists in
 ``%artists%`` except the first, which can be used to create a "feat." list.  This
-would look something like ``$setmulti(supporting_artists,$slice(%artists%,1,))``.
+would look something like ``$setmulti(supporting_artists,$slice(%artists%,1))``.
 
 
 **Example:**
@@ -33,10 +33,10 @@ The following statements will return the values indicated:
 .. code-block:: taggerscript
 
     $set(foo,A; B; C; D; E)
-    $slice(%foo%,1,)                       ==>  ""
+    $slice(%foo%,1)                        ==>  ""
 
     $setmulti(foo,A; B; C; D; E)
-    $slice(%foo%,1,)                       ==>  "B; C; D; E"
+    $slice(%foo%,1)                        ==>  "B; C; D; E"
 
     $slice(A; B; C; D; E,1,)               ==>  "B; C; D; E"
     $slice(A; B; C; D; E,1,3)              ==>  "B; C"

--- a/functions/func_slice.rst
+++ b/functions/func_slice.rst
@@ -33,12 +33,12 @@ The following statements will return the values indicated:
 .. code-block:: taggerscript
 
     $set(foo,A; B; C; D; E)
-    $slice(%foo%,1)                        ==>  ""
+    $slice(%foo%,1,)                       ==>  ""
 
     $setmulti(foo,A; B; C; D; E)
-    $slice(%foo%,1)                        ==>  "B; C; D; E"
+    $slice(%foo%,1,)                       ==>  "B; C; D; E"
 
-    $slice(A; B; C; D; E,1)                ==>  "B; C; D; E"
+    $slice(A; B; C; D; E,1,)               ==>  "B; C; D; E"
     $slice(A; B; C; D; E,1,3)              ==>  "B; C"
     $slice(A; B; C; D; E,,3)               ==>  "A; B; C"
     $slice(A; B; C; D; E,1,3)              ==>  "B; C"


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Some of the examples for the $slice() function were missing a comma and would actually show as errors in the script because of incorrect number of arguments

### Description of the Change

Add the missing commas.

### Additional Action Required

None.
