### PR TITLE
Add option to `$copymerge()` function

### DIFF
--- a/functions/func_copymerge.rst
+++ b/functions/func_copymerge.rst
@@ -5,7 +5,7 @@
 $copymerge
 ==========
 
-| Usage: **$copymerge(target,source)**
+| Usage: **$copymerge(target,source[,keep_duplicates])**
 | Category: assignment
 | Implemented: Picard 1.0
 
@@ -14,6 +14,8 @@ $copymerge
 Merges metadata from variable ``source`` into ``target``, removing duplicates and appending to the end,
 so retaining the original ordering. Like :ref:`func_copy`, this will also copy multi-valued variables
 without flattening them.  Following the operation, ``target`` will be a multi-value variable.
+
+If ``keep_duplicates`` is set, then the duplicates will not be removed from the result.
 
 Note that the variable names for ``target`` and ``source`` are passed directly without enclosing them
 in percent signs '%'.
@@ -44,3 +46,7 @@ The following statements will yield the values for ``target`` as indicated:
     $set(target,zero; one; zero)
     $set(source,one; two; three)
     $copymerge(target,source)     ==>  "zero, one; two; three"
+
+    $setmulti(target,zero; two)
+    $setmulti(source,one; two)
+    $copymerge(target,source,1)   ==>  "zero; two; one; two"


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

In https://github.com/metabrainz/picard/pull/2020 a new option is being added to the `$copymerge()` function.

### Description of the Change

Add information about the new option.

### Additional Action Required

Do not merge until the change in Picard has been released, currently planned for Picard v2.8.

Once merged, update the translation files.