### PR TITLE
Add links between filenaming editor and tutorial.

### DIFF
--- a/config/options_filerenaming.rst
+++ b/config/options_filerenaming.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _opt_file_naming:
+
 :index:`File Naming Options <pair: configuration; file naming>`
 ================================================================
 
@@ -92,7 +94,7 @@ These options determine how Picard handles files when they are saved with update
    As of Picard version 2.7, multiple file naming scripts are supported.  This option allows the user to select the
    file naming script to use from the list of scripts available. Scripts can be either system preset scripts or
    user-defined scripts. The available scripts are managed in the :doc:`File naming script editor <options_filerenaming_editor>`
-   screen, which is displayed when the "Open the file naming script editor" button is selected.
+   screen, which is displayed when the :guilabel:`Edit script...` button is selected.
 
 **Files will be named like this**
 

--- a/config/options_filerenaming_editor.rst
+++ b/config/options_filerenaming_editor.rst
@@ -1,7 +1,9 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _opt_naming_script_editor:
+
 :index:`File Naming Script Editor <pair: file naming; script editor>`
-==================================================================================
+======================================================================
 
 The file naming script editor is used to manage the file naming scripts available for use by Picard.
 Each script has a title that will show up in the script selection box.  There are two types of scripts
@@ -53,6 +55,7 @@ The editor screen has the following sections:
    Scripts are often discussed in the `MetaBrainz Community Forum <https://community.metabrainz.org/>`_,
    and there is a thread specific to `file naming and script snippets
    <https://community.metabrainz.org/t/repository-for-neat-file-name-string-patterns-and-tagger-script-snippets/2786/>`_.
+   There is also a tutorial on :doc:`/tutorials/naming_script` available.
 
    .. note::
 

--- a/tutorials/naming_script.rst
+++ b/tutorials/naming_script.rst
@@ -1,11 +1,17 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _tutorial_naming_script:
+
 Writing a :index:`File Naming Script <script; file naming, file naming script>`
 ==================================================================================
 
 Writing a script to organize and name your files is actually not that hard -- just don’t get intimidated by all the
 '$', '%' and parentheses. If you can write down a pattern like "**ARTIST - (YEAR) ALBUM NAME/TRACK - SONG TITLE**"
 of how you want the files and folders named, you can quite easily translate this to the proper script.
+
+To get started, first open the :doc:`/config/options_filerenaming_editor`, either by selecting :menuselection:`"Options --> Open file naming script editor..."`
+from Picard's main menu bar or by clicking the :guilabel:`Edit script...` button on the :doc:`/config/options_filerenaming` configuration page.
+From this screen, you can start a new script for your work.
 
 Note that the use of a '/' in the formatting string separates the output directory from the file name. The formatting
 string is allowed to contain any number of '/' characters. Everything before the last '/' is the directory location,


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [x] Other

### Reason for the Change

File naming tutorial page didn't explain how to get started writing a new file naming script, and the file naming script options didn't refer to the tutorial.

### Description of the Change

Add links between the file naming editor and tutorial pages.  Also minor text changes to match the button text in the dialog.

### Additional Action Required

Update translation POT and PO files.
