### PR TITLE
Add note about accessing tags with hyphens in the tag name

### DIFF
--- a/extending/scripting.rst
+++ b/extending/scripting.rst
@@ -36,6 +36,13 @@ start with a dollar sign and end with an argument list enclosed in parentheses (
    a backslash before the character to be escaped.  For example, to set a tag value to ``($1,000,000)``
    it would have to be entered as ``$set(test_tag,\(\$1\,000\,000\))``.
 
+.. note::
+
+   Usually you can access the values of a tag by the proper variable name. For example, if your tag
+   is called "rerecorded" you can use ``%rerecorded%``. But the hyphen is not a valid character for a
+   script variable, so ``%re-recorded%`` gives a syntax error. In cases like this you need to use
+   ``$get(re-recorded)``.
+
 Metadata Variables
 ------------------
 

--- a/functions/func_get.rst
+++ b/functions/func_get.rst
@@ -15,6 +15,12 @@ been set.  If ``name`` is another variable (e.g. ``%indirect%``) the value of th
 variable will be used as ``name``.  This allows the retrieval of dynamically named
 variables.
 
+.. note::
+
+   Usually you can access the values of a tag by the proper variable name. For example, if your tag
+   is called "rerecorded" you can use ``%rerecorded%``. But the hyphen is not a valid character for a
+   script variable, so ``%re-recorded%`` gives a syntax error. In cases like this you need to use
+   ``$get(re-recorded)``.
 
 **Example:**
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Tag names containing a hyphen cannot be accessed using the "%" method, but must use the `$get()` function.  This is not currently explained in the documentation.

### Description of the Change

Add a note based on outsidecontext's response to a question in the [Community Forum](https://community.metabrainz.org/t/help-with-field-data-entry/568128/2).

### Additional Action Required

Once merged, the translation files will need to be updated.
