### PR TITLE
Make the `$substr()` end parameter optional

### DIFF
--- a/functions/func_substr.rst
+++ b/functions/func_substr.rst
@@ -5,7 +5,7 @@
 $substr
 =======
 
-| Usage: **$substr(text,start,end)**
+| Usage: **$substr(text,start[,end])**
 | Category: text
 | Implemented: Picard 2.3
 
@@ -14,8 +14,9 @@ $substr
 Returns the substring of ``text`` beginning with the character at the ``start``
 index, up to (but not including) the character at the ``end`` index. Indexes are
 zero-based. Negative numbers will be counted back from the end of the string. If
-the start or end indexes are left blank, they will default to the start and end
-of the string respectively.  If the ``start`` index evaluates to a negative
+the start index is left blank, it will default to the start of the string.  If
+the end index is left blank or not included, it will default to the end
+of the string.  If the ``start`` index evaluates to a negative
 number (e.g.: ``text`` is "abc" and ``start`` is -10), it will default to the
 start of the string.  Similarly, if ``end`` index is a number greater than the
 number of characters in the string, it will default to the end of the string.


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The `end` parameter of the `$substr()` function was made truly optional in https://github.com/metabrainz/picard/pull/2039

### Description of the Change

Update the documentation to clarify that the parameter can be omitted completely.

### Additional Action Required

Hold merging this until Picard v2.8 has been released.

Once merged, the translation files need to be updated.
