### PR TITLE
Add the `%_musicbrainz_tracknumber%` variable

### DIFF
--- a/_locale/de/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/de/LC_MESSAGES/variables/variables_basic.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-18 09:49-0600\n"
+"POT-Creation-Date: 2022-01-26 13:55-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: de\n"
@@ -117,129 +117,139 @@ msgid ""
 msgstr ""
 
 #: ../../variables/variables_basic.rst:51
-msgid "**_pregap**"
+msgid "**_musicbrainz_tracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:53
+msgid ""
+"The track number written as on the MusicBrainz release, such as vinyl "
+"numbering (A1, A2...)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:55
+msgid "**_pregap**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:57
 msgid ""
 "Set to 1 if the track is a \"`pregap track "
 "<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
 "Picard 1.3.1*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:57
+#: ../../variables/variables_basic.rst:61
 msgid "**_primaryreleasetype**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:59
+#: ../../variables/variables_basic.rst:63
 msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:61
+#: ../../variables/variables_basic.rst:65
 msgid "**_rating**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:63
+#: ../../variables/variables_basic.rst:67
 msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:65
+#: ../../variables/variables_basic.rst:69
 msgid "**_recording_firstreleasedate**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:67
+#: ../../variables/variables_basic.rst:71
 msgid ""
 "The date of the earliest recording for a track in the format YYYY-MM-DD."
 "  (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:69
+#: ../../variables/variables_basic.rst:73
 msgid "**_releaseannotation**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:71
+#: ../../variables/variables_basic.rst:75
 msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid "**_releasecomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "**_releasecountries**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid ""
 "This provides the complete list of release countries for the release as a"
 " multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid "**_releasegroup**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:83
+#: ../../variables/variables_basic.rst:87
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but "
 "can be different."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid "**_releasegroupcomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid "Release Group disambiguation comment."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:91
+#: ../../variables/variables_basic.rst:95
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-"
 "MM-DD. This is intended to provide, for example, the release date of the "
 "vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "This is the same information provided by default in the ``originaldate`` "
 "tag."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:97
+#: ../../variables/variables_basic.rst:101
 msgid "**_releaselanguage**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid ""
 "Release Language as per `ISO 639-3 "
 "<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:103
+#: ../../variables/variables_basic.rst:107
 msgid "**_secondaryreleasetype**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:105
+#: ../../variables/variables_basic.rst:109
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
 " dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
 "spokenword)."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:107
+#: ../../variables/variables_basic.rst:111
 msgid "**_totalalbumtracks**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:113
 msgid "The total number of tracks across all discs of this release."
 msgstr ""
 

--- a/_locale/de/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/de/LC_MESSAGES/variables/variables_basic.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-26 13:55-0700\n"
+"POT-Creation-Date: 2022-01-26 16:21-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: de\n"
@@ -154,102 +154,110 @@ msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:69
-msgid "**_recording_firstreleasedate**"
+msgid "**_recording_comment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:71
+msgid "The disambiguation comment for the recording associated with a track."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:73
+msgid "**_recording_firstreleasedate**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:75
 msgid ""
 "The date of the earliest recording for a track in the format YYYY-MM-DD."
 "  (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid "**_releaseannotation**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "**_releasecomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid "**_releasecountries**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:83
+#: ../../variables/variables_basic.rst:87
 msgid ""
 "This provides the complete list of release countries for the release as a"
 " multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid "**_releasegroup**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but "
 "can be different."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid "**_releasegroupcomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:91
+#: ../../variables/variables_basic.rst:95
 msgid "Release Group disambiguation comment."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:93
+#: ../../variables/variables_basic.rst:97
 msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-"
 "MM-DD. This is intended to provide, for example, the release date of the "
 "vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid ""
 "This is the same information provided by default in the ``originaldate`` "
 "tag."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:101
+#: ../../variables/variables_basic.rst:105
 msgid "**_releaselanguage**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:103
+#: ../../variables/variables_basic.rst:107
 msgid ""
 "Release Language as per `ISO 639-3 "
 "<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:107
+#: ../../variables/variables_basic.rst:111
 msgid "**_secondaryreleasetype**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:113
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
 " dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
 "spokenword)."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:111
+#: ../../variables/variables_basic.rst:115
 msgid "**_totalalbumtracks**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:113
+#: ../../variables/variables_basic.rst:117
 msgid "The total number of tracks across all discs of this release."
 msgstr ""
 

--- a/_locale/fr/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/fr/LC_MESSAGES/variables/variables_basic.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-26 13:55-0700\n"
+"POT-Creation-Date: 2022-01-26 16:21-0700\n"
 "PO-Revision-Date: 2021-09-18 17:13+0000\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language: fr\n"
@@ -189,10 +189,19 @@ msgid "Rating 0-5 by MusicBrainz users."
 msgstr "Note 0-5 par les utilisateurs de MusicBrainz."
 
 #: ../../variables/variables_basic.rst:69
+#, fuzzy
+msgid "**_recording_comment**"
+msgstr "**_releasecomment**"
+
+#: ../../variables/variables_basic.rst:71
+msgid "The disambiguation comment for the recording associated with a track."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:73
 msgid "**_recording_firstreleasedate**"
 msgstr "**_recording_firstreleasedate**"
 
-#: ../../variables/variables_basic.rst:71
+#: ../../variables/variables_basic.rst:75
 msgid ""
 "The date of the earliest recording for a track in the format YYYY-MM-DD."
 "  (*Since Picard 2.6*)"
@@ -200,27 +209,27 @@ msgstr ""
 "Date du premier enregistrement d'une piste au format AAAA-MM-JJ. (*Depuis"
 " Picard 2.6*)"
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid "**_releaseannotation**"
 msgstr "**_releaseannotation**"
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr "Le commentaire d'annotation pour la version. (*depuis Picard 2,6*)"
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "**_releasecomment**"
 msgstr "**_releasecomment**"
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr "Le commentaire d'homonymie pour la version. (*depuis Picard 0,15*)"
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid "**_releasecountries**"
 msgstr "**_releasecountries**"
 
-#: ../../variables/variables_basic.rst:83
+#: ../../variables/variables_basic.rst:87
 msgid ""
 "This provides the complete list of release countries for the release as a"
 " multi-value variable. (*since Picard 2.3.1*)"
@@ -228,11 +237,11 @@ msgstr ""
 "Ceci fournit la liste complète des pays de la version pour la version "
 "comme une variable à plusieurs valeurs. (*depuis Picard 2.3.1*)"
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid "**_releasegroup**"
 msgstr "**_releasegroup**"
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but "
 "can be different."
@@ -240,19 +249,19 @@ msgstr ""
 "Le titre du groupe de versions qui est généralement le même que le titre "
 "de l'album, mais peut être différent."
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid "**_releasegroupcomment**"
 msgstr "**_releasegroupcomment**"
 
-#: ../../variables/variables_basic.rst:91
+#: ../../variables/variables_basic.rst:95
 msgid "Release Group disambiguation comment."
 msgstr "Le commentaire d'homonymie pour le groupe de version."
 
-#: ../../variables/variables_basic.rst:93
+#: ../../variables/variables_basic.rst:97
 msgid "**_releasegroup_firstreleasedate**"
 msgstr "**_releasegroup_firstreleasedate**"
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-"
 "MM-DD. This is intended to provide, for example, the release date of the "
@@ -262,7 +271,7 @@ msgstr ""
 "AAAA-MM-JJ. Ceci est destiné à fournir, par exemple, la date de sortie de"
 " la version vinyle de ce que vous avez sur CD. (*Depuis Picard 2.6*)"
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid ""
 "This is the same information provided by default in the ``originaldate`` "
 "tag."
@@ -270,11 +279,11 @@ msgstr ""
 "Ce sont les mêmes informations fournies par défaut dans la balise "
 "``originaldate``."
 
-#: ../../variables/variables_basic.rst:101
+#: ../../variables/variables_basic.rst:105
 msgid "**_releaselanguage**"
 msgstr "**_releaselanguage**"
 
-#: ../../variables/variables_basic.rst:103
+#: ../../variables/variables_basic.rst:107
 msgid ""
 "Release Language as per `ISO 639-3 "
 "<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
@@ -282,11 +291,11 @@ msgstr ""
 "La langue de la version selon `ISO 639-3 "
 "<https://fr.wikipedia.org/wiki/ISO_639-3>`_. (*depuis Picard 0,10*)"
 
-#: ../../variables/variables_basic.rst:107
+#: ../../variables/variables_basic.rst:111
 msgid "**_secondaryreleasetype**"
 msgstr "**_secondaryreleasetype**"
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:113
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
 " dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
@@ -296,11 +305,11 @@ msgstr ""
 "(c'est-à-dire : livre audio, compilation, DJ-mix, interview, live, "
 "mixtape / street, remix, bande sonore ou speechword)."
 
-#: ../../variables/variables_basic.rst:111
+#: ../../variables/variables_basic.rst:115
 msgid "**_totalalbumtracks**"
 msgstr "**_totalalbumtracks**"
 
-#: ../../variables/variables_basic.rst:113
+#: ../../variables/variables_basic.rst:117
 msgid "The total number of tracks across all discs of this release."
 msgstr "Le nombre total de pistes sur tous les disques de cette version."
 

--- a/_locale/fr/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/fr/LC_MESSAGES/variables/variables_basic.po
@@ -8,17 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-18 09:49-0600\n"
+"POT-Creation-Date: 2022-01-26 13:55-0700\n"
 "PO-Revision-Date: 2021-09-18 17:13+0000\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
-"Language-Team: French <https://translate.uploadedlobster.com/projects/"
-"picard-docs/variablesvariables_basic/fr/>\n"
 "Language: fr\n"
+"Language-Team: French <https://translate.uploadedlobster.com/projects"
+"/picard-docs/variablesvariables_basic/fr/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.7.2\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../variables/variables_basic.rst:8
@@ -53,9 +52,9 @@ msgid ""
 "tracks. (*since Picard 1.3*)"
 msgstr ""
 "Le numéro absolu de cette piste sans tenir compte du numéro de disque "
-"(c'est-à-dire : ``%_absolutetracknumber%`` de ``%_totalbumtracks%``). Par "
-"exemple, cette valeur serait 11 pour la deuxième piste du disque 2 où le "
-"disque 1 a 9 pistes. (*depuis Picard 1.3*)"
+"(c'est-à-dire : ``%_absolutetracknumber%`` de ``%_totalbumtracks%``). Par"
+" exemple, cette valeur serait 11 pour la deuxième piste du disque 2 où le"
+" disque 1 a 9 pistes. (*depuis Picard 1.3*)"
 
 #: ../../variables/variables_basic.rst:21
 msgid "**_albumartists**"
@@ -140,16 +139,28 @@ msgid ""
 "attached to discs 2 and 3 of the set."
 msgstr ""
 "Cette variable à valeurs multiples contient une liste de tous les "
-"identifiants de disque associés à la version sélectionnée.  La liste fournie "
-"pour chaque support ne comprend que les identifiants de disque associés à ce "
-"support. Par exemple, la liste fournie pour le disque 1 d'un ensemble de "
-"trois CD ne comprendra pas les identifiants des disques 2 et 3 de l'ensemble."
+"identifiants de disque associés à la version sélectionnée.  La liste "
+"fournie pour chaque support ne comprend que les identifiants de disque "
+"associés à ce support. Par exemple, la liste fournie pour le disque 1 "
+"d'un ensemble de trois CD ne comprendra pas les identifiants des disques "
+"2 et 3 de l'ensemble."
 
 #: ../../variables/variables_basic.rst:51
+#, fuzzy
+msgid "**_musicbrainz_tracknumber**"
+msgstr "**_musicbrainz_discids**"
+
+#: ../../variables/variables_basic.rst:53
+msgid ""
+"The track number written as on the MusicBrainz release, such as vinyl "
+"numbering (A1, A2...)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:55
 msgid "**_pregap**"
 msgstr "**_pregap**"
 
-#: ../../variables/variables_basic.rst:53
+#: ../../variables/variables_basic.rst:57
 msgid ""
 "Set to 1 if the track is a \"`pregap track "
 "<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
@@ -159,29 +170,29 @@ msgstr ""
 "<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*depuis "
 "Picard 1.3.1*)"
 
-#: ../../variables/variables_basic.rst:57
+#: ../../variables/variables_basic.rst:61
 msgid "**_primaryreleasetype**"
 msgstr "**_primaryreleasetype**"
 
-#: ../../variables/variables_basic.rst:59
+#: ../../variables/variables_basic.rst:63
 msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
 msgstr ""
-"Le type de groupe principal de version (c'est-à-dire : album, single, ep, "
-"diffusion ou autre)."
+"Le type de groupe principal de version (c'est-à-dire : album, single, ep,"
+" diffusion ou autre)."
 
-#: ../../variables/variables_basic.rst:61
+#: ../../variables/variables_basic.rst:65
 msgid "**_rating**"
 msgstr "**_rating**"
 
-#: ../../variables/variables_basic.rst:63
+#: ../../variables/variables_basic.rst:67
 msgid "Rating 0-5 by MusicBrainz users."
 msgstr "Note 0-5 par les utilisateurs de MusicBrainz."
 
-#: ../../variables/variables_basic.rst:65
+#: ../../variables/variables_basic.rst:69
 msgid "**_recording_firstreleasedate**"
 msgstr "**_recording_firstreleasedate**"
 
-#: ../../variables/variables_basic.rst:67
+#: ../../variables/variables_basic.rst:71
 msgid ""
 "The date of the earliest recording for a track in the format YYYY-MM-DD."
 "  (*Since Picard 2.6*)"
@@ -189,27 +200,27 @@ msgstr ""
 "Date du premier enregistrement d'une piste au format AAAA-MM-JJ. (*Depuis"
 " Picard 2.6*)"
 
-#: ../../variables/variables_basic.rst:69
+#: ../../variables/variables_basic.rst:73
 msgid "**_releaseannotation**"
 msgstr "**_releaseannotation**"
 
-#: ../../variables/variables_basic.rst:71
+#: ../../variables/variables_basic.rst:75
 msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr "Le commentaire d'annotation pour la version. (*depuis Picard 2,6*)"
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid "**_releasecomment**"
 msgstr "**_releasecomment**"
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr "Le commentaire d'homonymie pour la version. (*depuis Picard 0,15*)"
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "**_releasecountries**"
 msgstr "**_releasecountries**"
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid ""
 "This provides the complete list of release countries for the release as a"
 " multi-value variable. (*since Picard 2.3.1*)"
@@ -217,11 +228,11 @@ msgstr ""
 "Ceci fournit la liste complète des pays de la version pour la version "
 "comme une variable à plusieurs valeurs. (*depuis Picard 2.3.1*)"
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid "**_releasegroup**"
 msgstr "**_releasegroup**"
 
-#: ../../variables/variables_basic.rst:83
+#: ../../variables/variables_basic.rst:87
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but "
 "can be different."
@@ -229,19 +240,19 @@ msgstr ""
 "Le titre du groupe de versions qui est généralement le même que le titre "
 "de l'album, mais peut être différent."
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid "**_releasegroupcomment**"
 msgstr "**_releasegroupcomment**"
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid "Release Group disambiguation comment."
 msgstr "Le commentaire d'homonymie pour le groupe de version."
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid "**_releasegroup_firstreleasedate**"
 msgstr "**_releasegroup_firstreleasedate**"
 
-#: ../../variables/variables_basic.rst:91
+#: ../../variables/variables_basic.rst:95
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-"
 "MM-DD. This is intended to provide, for example, the release date of the "
@@ -251,7 +262,7 @@ msgstr ""
 "AAAA-MM-JJ. Ceci est destiné à fournir, par exemple, la date de sortie de"
 " la version vinyle de ce que vous avez sur CD. (*Depuis Picard 2.6*)"
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "This is the same information provided by default in the ``originaldate`` "
 "tag."
@@ -259,11 +270,11 @@ msgstr ""
 "Ce sont les mêmes informations fournies par défaut dans la balise "
 "``originaldate``."
 
-#: ../../variables/variables_basic.rst:97
+#: ../../variables/variables_basic.rst:101
 msgid "**_releaselanguage**"
 msgstr "**_releaselanguage**"
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid ""
 "Release Language as per `ISO 639-3 "
 "<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
@@ -271,25 +282,25 @@ msgstr ""
 "La langue de la version selon `ISO 639-3 "
 "<https://fr.wikipedia.org/wiki/ISO_639-3>`_. (*depuis Picard 0,10*)"
 
-#: ../../variables/variables_basic.rst:103
+#: ../../variables/variables_basic.rst:107
 msgid "**_secondaryreleasetype**"
 msgstr "**_secondaryreleasetype**"
 
-#: ../../variables/variables_basic.rst:105
+#: ../../variables/variables_basic.rst:109
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
 " dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
 "spokenword)."
 msgstr ""
-"Zéro ou plus de types secondaires pour le groupe de versions (c'est-à-dire : "
-"livre audio, compilation, DJ-mix, interview, live, mixtape / street, remix, "
-"bande sonore ou speechword)."
+"Zéro ou plus de types secondaires pour le groupe de versions "
+"(c'est-à-dire : livre audio, compilation, DJ-mix, interview, live, "
+"mixtape / street, remix, bande sonore ou speechword)."
 
-#: ../../variables/variables_basic.rst:107
+#: ../../variables/variables_basic.rst:111
 msgid "**_totalalbumtracks**"
 msgstr "**_totalalbumtracks**"
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:113
 msgid "The total number of tracks across all discs of this release."
 msgstr "Le nombre total de pistes sur tous les disques de cette version."
 
@@ -431,3 +442,4 @@ msgstr "Le nombre total de pistes sur tous les disques de cette version."
 #~ "CD. (*Depuis Picard 2.6*. Avant Picard"
 #~ " 2.6, ces informations étaient disponibles"
 #~ " dans la balise ``originaldate``.)"
+

--- a/_locale/gettext/variables/variables_basic.pot
+++ b/_locale/gettext/variables/variables_basic.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
+"Project-Id-Version: MusicBrainz Picard v2.7.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-04 09:38-0600\n"
+"POT-Creation-Date: 2022-01-26 13:55-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -93,109 +93,117 @@ msgid "This multi-value variable contains a list of all of the disc ids attached
 msgstr ""
 
 #: ../../variables/variables_basic.rst:51
-msgid "**_pregap**"
+msgid "**_musicbrainz_tracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:53
-msgid "Set to 1 if the track is a \"`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since Picard 1.3.1*)"
+msgid "The track number written as on the MusicBrainz release, such as vinyl numbering (A1, A2...)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:55
+msgid "**_pregap**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:57
-msgid "**_primaryreleasetype**"
-msgstr ""
-
-#: ../../variables/variables_basic.rst:59
-msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
+msgid "Set to 1 if the track is a \"`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since Picard 1.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:61
-msgid "**_rating**"
+msgid "**_primaryreleasetype**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:63
-msgid "Rating 0-5 by MusicBrainz users."
+msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:65
-msgid "**_recording_firstreleasedate**"
+msgid "**_rating**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:67
-msgid "The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)"
+msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:69
-msgid "**_releaseannotation**"
+msgid "**_recording_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:71
-msgid "The annotation comment for the release. (*since Picard 2.6*)"
+msgid "The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:73
-msgid "**_releasecomment**"
+msgid "**_releaseannotation**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:75
-msgid "Release disambiguation comment. (*since Picard 0.15*)"
+msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:77
-msgid "**_releasecountries**"
+msgid "**_releasecomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:79
-msgid "This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)"
+msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:81
-msgid "**_releasegroup**"
+msgid "**_releasecountries**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:83
-msgid "Release Group Title which is typically the same as the Album Title, but can be different."
+msgid "This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:85
-msgid "**_releasegroupcomment**"
+msgid "**_releasegroup**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:87
-msgid "Release Group disambiguation comment."
+msgid "Release Group Title which is typically the same as the Album Title, but can be different."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:89
-msgid "**_releasegroup_firstreleasedate**"
+msgid "**_releasegroupcomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:91
-msgid "The date of the earliest release in the Release Group in the format YYYY-MM-DD. This is intended to provide, for example, the release date of the vinyl version of what you have on CD. (*Since Picard 2.6*)"
+msgid "Release Group disambiguation comment."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:93
+msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:95
-msgid "This is the same information provided by default in the ``originaldate`` tag."
-msgstr ""
-
-#: ../../variables/variables_basic.rst:97
-msgid "**_releaselanguage**"
+msgid "The date of the earliest release in the Release Group in the format YYYY-MM-DD. This is intended to provide, for example, the release date of the vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:99
-msgid "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
+msgid "This is the same information provided by default in the ``originaldate`` tag."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:101
+msgid "**_releaselanguage**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:103
-msgid "**_secondaryreleasetype**"
-msgstr ""
-
-#: ../../variables/variables_basic.rst:105
-msgid "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
+msgid "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:107
-msgid "**_totalalbumtracks**"
+msgid "**_secondaryreleasetype**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:109
+msgid "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:111
+msgid "**_totalalbumtracks**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:113
 msgid "The total number of tracks across all discs of this release."
 msgstr ""

--- a/_locale/gettext/variables/variables_basic.pot
+++ b/_locale/gettext/variables/variables_basic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-26 13:55-0700\n"
+"POT-Creation-Date: 2022-01-26 16:21-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,85 +125,93 @@ msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:69
-msgid "**_recording_firstreleasedate**"
+msgid "**_recording_comment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:71
-msgid "The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)"
+msgid "The disambiguation comment for the recording associated with a track."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:73
-msgid "**_releaseannotation**"
+msgid "**_recording_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:75
-msgid "The annotation comment for the release. (*since Picard 2.6*)"
+msgid "The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:77
-msgid "**_releasecomment**"
+msgid "**_releaseannotation**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:79
-msgid "Release disambiguation comment. (*since Picard 0.15*)"
+msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:81
-msgid "**_releasecountries**"
+msgid "**_releasecomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:83
-msgid "This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)"
+msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:85
-msgid "**_releasegroup**"
+msgid "**_releasecountries**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:87
-msgid "Release Group Title which is typically the same as the Album Title, but can be different."
+msgid "This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:89
-msgid "**_releasegroupcomment**"
+msgid "**_releasegroup**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:91
-msgid "Release Group disambiguation comment."
+msgid "Release Group Title which is typically the same as the Album Title, but can be different."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:93
-msgid "**_releasegroup_firstreleasedate**"
+msgid "**_releasegroupcomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:95
-msgid "The date of the earliest release in the Release Group in the format YYYY-MM-DD. This is intended to provide, for example, the release date of the vinyl version of what you have on CD. (*Since Picard 2.6*)"
+msgid "Release Group disambiguation comment."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:97
+msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:99
-msgid "This is the same information provided by default in the ``originaldate`` tag."
-msgstr ""
-
-#: ../../variables/variables_basic.rst:101
-msgid "**_releaselanguage**"
+msgid "The date of the earliest release in the Release Group in the format YYYY-MM-DD. This is intended to provide, for example, the release date of the vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:103
-msgid "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
+msgid "This is the same information provided by default in the ``originaldate`` tag."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:105
+msgid "**_releaselanguage**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:107
-msgid "**_secondaryreleasetype**"
-msgstr ""
-
-#: ../../variables/variables_basic.rst:109
-msgid "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
+msgid "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:111
-msgid "**_totalalbumtracks**"
+msgid "**_secondaryreleasetype**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:113
+msgid "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:115
+msgid "**_totalalbumtracks**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:117
 msgid "The total number of tracks across all discs of this release."
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/nb_NO/LC_MESSAGES/variables/variables_basic.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-26 13:55-0700\n"
+"POT-Creation-Date: 2022-01-26 16:21-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: nb_NO\n"
@@ -154,102 +154,110 @@ msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:69
-msgid "**_recording_firstreleasedate**"
+msgid "**_recording_comment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:71
+msgid "The disambiguation comment for the recording associated with a track."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:73
+msgid "**_recording_firstreleasedate**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:75
 msgid ""
 "The date of the earliest recording for a track in the format YYYY-MM-DD."
 "  (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid "**_releaseannotation**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "**_releasecomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid "**_releasecountries**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:83
+#: ../../variables/variables_basic.rst:87
 msgid ""
 "This provides the complete list of release countries for the release as a"
 " multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid "**_releasegroup**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but "
 "can be different."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid "**_releasegroupcomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:91
+#: ../../variables/variables_basic.rst:95
 msgid "Release Group disambiguation comment."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:93
+#: ../../variables/variables_basic.rst:97
 msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-"
 "MM-DD. This is intended to provide, for example, the release date of the "
 "vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid ""
 "This is the same information provided by default in the ``originaldate`` "
 "tag."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:101
+#: ../../variables/variables_basic.rst:105
 msgid "**_releaselanguage**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:103
+#: ../../variables/variables_basic.rst:107
 msgid ""
 "Release Language as per `ISO 639-3 "
 "<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:107
+#: ../../variables/variables_basic.rst:111
 msgid "**_secondaryreleasetype**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:113
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
 " dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
 "spokenword)."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:111
+#: ../../variables/variables_basic.rst:115
 msgid "**_totalalbumtracks**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:113
+#: ../../variables/variables_basic.rst:117
 msgid "The total number of tracks across all discs of this release."
 msgstr ""
 

--- a/_locale/nb_NO/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/nb_NO/LC_MESSAGES/variables/variables_basic.po
@@ -1,31 +1,38 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) This documentation is licensed under CC0 1.0.
-# This file is distributed under the same license as the MusicBrainz Picard package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# This file is distributed under the same license as the MusicBrainz Picard
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-06 09:47-0600\n"
+"POT-Creation-Date: 2022-01-26 13:55-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: nb_NO\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
 
 #: ../../variables/variables_basic.rst:8
 msgid ":index:`Basic Variables <variables; basic>`"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:10
-msgid "These variables are populated from MusicBrainz data for most releases, without any special Picard settings."
+msgid ""
+"These variables are populated from MusicBrainz data for most releases, "
+"without any special Picard settings."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:14
-msgid "Variables will not be created if there was no value retrieved for the variable from the MusicBrainz database."
+msgid ""
+"Variables will not be created if there was no value retrieved for the "
+"variable from the MusicBrainz database."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:16
@@ -33,7 +40,11 @@ msgid "**_absolutetracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:18
-msgid "The absolute number of this track disregarding the disc number (i.e.: ``%_absolutetracknumber%`` of ``%_totalalbumtracks%``). For example, this value would be 11 for the second track on disc 2 where disc 1 has 9 tracks. (*since Picard 1.3*)"
+msgid ""
+"The absolute number of this track disregarding the disc number (i.e.: "
+"``%_absolutetracknumber%`` of ``%_totalalbumtracks%``). For example, this"
+" value would be 11 for the second track on disc 2 where disc 1 has 9 "
+"tracks. (*since Picard 1.3*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:21
@@ -65,7 +76,10 @@ msgid "**_datatrack**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:35
-msgid "Set to 1 if the track is a \"`data track <https://wiki.musicbrainz.org/Style/Unknown_and_untitled/Special_purpose_track_title#Data_tracks>`_\". (*since Picard 1.3.1*)"
+msgid ""
+"Set to 1 if the track is a \"`data track "
+"<https://wiki.musicbrainz.org/Style/Unknown_and_untitled/Special_purpose_track_title#Data_tracks>`_\"."
+" (*since Picard 1.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:37
@@ -73,7 +87,10 @@ msgid "**_discpregap**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:39
-msgid "Set to 1 if the disc the track is on has a \"`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since Picard 1.4*)"
+msgid ""
+"Set to 1 if the disc the track is on has a \"`pregap track "
+"<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
+"Picard 1.4*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:41
@@ -81,7 +98,9 @@ msgid "**_multiartist**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:43
-msgid "0 if tracks on the album all have the same primary artist, 1 otherwise. (*since Picard 1.3*)"
+msgid ""
+"0 if tracks on the album all have the same primary artist, 1 otherwise. "
+"(*since Picard 1.3*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:45
@@ -89,113 +108,148 @@ msgid "**_musicbrainz_discids**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:47
-msgid "This multi-value variable contains a list of all of the disc ids attached to the selected release.  The list provided for each medium only includes the disc ids attached to that medium. For example, the list provided for Disc 1 of a three CD set will not include the disc ids attached to discs 2 and 3 of the set."
+msgid ""
+"This multi-value variable contains a list of all of the disc ids attached"
+" to the selected release.  The list provided for each medium only "
+"includes the disc ids attached to that medium. For example, the list "
+"provided for Disc 1 of a three CD set will not include the disc ids "
+"attached to discs 2 and 3 of the set."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:51
-msgid "**_pregap**"
+msgid "**_musicbrainz_tracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:53
-msgid "Set to 1 if the track is a \"`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since Picard 1.3.1*)"
+msgid ""
+"The track number written as on the MusicBrainz release, such as vinyl "
+"numbering (A1, A2...)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:55
+msgid "**_pregap**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:57
-msgid "**_primaryreleasetype**"
-msgstr ""
-
-#: ../../variables/variables_basic.rst:59
-msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
+msgid ""
+"Set to 1 if the track is a \"`pregap track "
+"<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
+"Picard 1.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:61
-msgid "**_rating**"
+msgid "**_primaryreleasetype**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:63
-msgid "Rating 0-5 by MusicBrainz users."
+msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:65
-msgid "**_recording_firstreleasedate**"
+msgid "**_rating**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:67
-msgid "The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)"
+msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:69
-msgid "**_releaseannotation**"
+msgid "**_recording_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:71
-msgid "The annotation comment for the release. (*since Picard 2.6*)"
+msgid ""
+"The date of the earliest recording for a track in the format YYYY-MM-DD."
+"  (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:73
-msgid "**_releasecomment**"
+msgid "**_releaseannotation**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:75
-msgid "Release disambiguation comment. (*since Picard 0.15*)"
+msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:77
-msgid "**_releasecountries**"
+msgid "**_releasecomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:79
-msgid "This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)"
+msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:81
-msgid "**_releasegroup**"
+msgid "**_releasecountries**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:83
-msgid "Release Group Title which is typically the same as the Album Title, but can be different."
+msgid ""
+"This provides the complete list of release countries for the release as a"
+" multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:85
-msgid "**_releasegroupcomment**"
+msgid "**_releasegroup**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:87
-msgid "Release Group disambiguation comment."
+msgid ""
+"Release Group Title which is typically the same as the Album Title, but "
+"can be different."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:89
-msgid "**_releasegroup_firstreleasedate**"
+msgid "**_releasegroupcomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:91
-msgid "The date of the earliest release in the Release Group in the format YYYY-MM-DD. This is intended to provide, for example, the release date of the vinyl version of what you have on CD. (*Since Picard 2.6*)"
+msgid "Release Group disambiguation comment."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:93
+msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:95
-msgid "This is the same information provided by default in the ``originaldate`` tag."
-msgstr ""
-
-#: ../../variables/variables_basic.rst:97
-msgid "**_releaselanguage**"
+msgid ""
+"The date of the earliest release in the Release Group in the format YYYY-"
+"MM-DD. This is intended to provide, for example, the release date of the "
+"vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:99
-msgid "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
+msgid ""
+"This is the same information provided by default in the ``originaldate`` "
+"tag."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:101
+msgid "**_releaselanguage**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:103
-msgid "**_secondaryreleasetype**"
-msgstr ""
-
-#: ../../variables/variables_basic.rst:105
-msgid "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
+msgid ""
+"Release Language as per `ISO 639-3 "
+"<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:107
-msgid "**_totalalbumtracks**"
+msgid "**_secondaryreleasetype**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:109
+msgid ""
+"Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
+" dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
+"spokenword)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:111
+msgid "**_totalalbumtracks**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:113
 msgid "The total number of tracks across all discs of this release."
 msgstr ""
+

--- a/_locale/nl/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/nl/LC_MESSAGES/variables/variables_basic.po
@@ -1,31 +1,38 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) This documentation is licensed under CC0 1.0.
-# This file is distributed under the same license as the MusicBrainz Picard package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# This file is distributed under the same license as the MusicBrainz Picard
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-04 09:38-0600\n"
+"POT-Creation-Date: 2022-01-26 16:21-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: nl\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
 
 #: ../../variables/variables_basic.rst:8
 msgid ":index:`Basic Variables <variables; basic>`"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:10
-msgid "These variables are populated from MusicBrainz data for most releases, without any special Picard settings."
+msgid ""
+"These variables are populated from MusicBrainz data for most releases, "
+"without any special Picard settings."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:14
-msgid "Variables will not be created if there was no value retrieved for the variable from the MusicBrainz database."
+msgid ""
+"Variables will not be created if there was no value retrieved for the "
+"variable from the MusicBrainz database."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:16
@@ -33,7 +40,11 @@ msgid "**_absolutetracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:18
-msgid "The absolute number of this track disregarding the disc number (i.e.: ``%_absolutetracknumber%`` of ``%_totalalbumtracks%``). For example, this value would be 11 for the second track on disc 2 where disc 1 has 9 tracks. (*since Picard 1.3*)"
+msgid ""
+"The absolute number of this track disregarding the disc number (i.e.: "
+"``%_absolutetracknumber%`` of ``%_totalalbumtracks%``). For example, this"
+" value would be 11 for the second track on disc 2 where disc 1 has 9 "
+"tracks. (*since Picard 1.3*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:21
@@ -65,7 +76,10 @@ msgid "**_datatrack**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:35
-msgid "Set to 1 if the track is a \"`data track <https://wiki.musicbrainz.org/Style/Unknown_and_untitled/Special_purpose_track_title#Data_tracks>`_\". (*since Picard 1.3.1*)"
+msgid ""
+"Set to 1 if the track is a \"`data track "
+"<https://wiki.musicbrainz.org/Style/Unknown_and_untitled/Special_purpose_track_title#Data_tracks>`_\"."
+" (*since Picard 1.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:37
@@ -73,7 +87,10 @@ msgid "**_discpregap**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:39
-msgid "Set to 1 if the disc the track is on has a \"`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since Picard 1.4*)"
+msgid ""
+"Set to 1 if the disc the track is on has a \"`pregap track "
+"<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
+"Picard 1.4*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:41
@@ -81,7 +98,9 @@ msgid "**_multiartist**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:43
-msgid "0 if tracks on the album all have the same primary artist, 1 otherwise. (*since Picard 1.3*)"
+msgid ""
+"0 if tracks on the album all have the same primary artist, 1 otherwise. "
+"(*since Picard 1.3*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:45
@@ -89,113 +108,156 @@ msgid "**_musicbrainz_discids**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:47
-msgid "This multi-value variable contains a list of all of the disc ids attached to the selected release.  The list provided for each medium only includes the disc ids attached to that medium. For example, the list provided for Disc 1 of a three CD set will not include the disc ids attached to discs 2 and 3 of the set."
+msgid ""
+"This multi-value variable contains a list of all of the disc ids attached"
+" to the selected release.  The list provided for each medium only "
+"includes the disc ids attached to that medium. For example, the list "
+"provided for Disc 1 of a three CD set will not include the disc ids "
+"attached to discs 2 and 3 of the set."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:51
-msgid "**_pregap**"
+msgid "**_musicbrainz_tracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:53
-msgid "Set to 1 if the track is a \"`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since Picard 1.3.1*)"
+msgid ""
+"The track number written as on the MusicBrainz release, such as vinyl "
+"numbering (A1, A2...)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:55
+msgid "**_pregap**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:57
-msgid "**_primaryreleasetype**"
-msgstr ""
-
-#: ../../variables/variables_basic.rst:59
-msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
+msgid ""
+"Set to 1 if the track is a \"`pregap track "
+"<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
+"Picard 1.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:61
-msgid "**_rating**"
+msgid "**_primaryreleasetype**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:63
-msgid "Rating 0-5 by MusicBrainz users."
+msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:65
-msgid "**_recording_firstreleasedate**"
+msgid "**_rating**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:67
-msgid "The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)"
+msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:69
-msgid "**_releaseannotation**"
+msgid "**_recording_comment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:71
-msgid "The annotation comment for the release. (*since Picard 2.6*)"
+msgid "The disambiguation comment for the recording associated with a track."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:73
-msgid "**_releasecomment**"
+msgid "**_recording_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:75
-msgid "Release disambiguation comment. (*since Picard 0.15*)"
+msgid ""
+"The date of the earliest recording for a track in the format YYYY-MM-DD."
+"  (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:77
-msgid "**_releasecountries**"
+msgid "**_releaseannotation**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:79
-msgid "This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)"
+msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:81
-msgid "**_releasegroup**"
+msgid "**_releasecomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:83
-msgid "Release Group Title which is typically the same as the Album Title, but can be different."
+msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:85
-msgid "**_releasegroupcomment**"
+msgid "**_releasecountries**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:87
-msgid "Release Group disambiguation comment."
+msgid ""
+"This provides the complete list of release countries for the release as a"
+" multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:89
-msgid "**_releasegroup_firstreleasedate**"
+msgid "**_releasegroup**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:91
-msgid "The date of the earliest release in the Release Group in the format YYYY-MM-DD. This is intended to provide, for example, the release date of the vinyl version of what you have on CD. (*Since Picard 2.6*)"
+msgid ""
+"Release Group Title which is typically the same as the Album Title, but "
+"can be different."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:93
+msgid "**_releasegroupcomment**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:95
-msgid "This is the same information provided by default in the ``originaldate`` tag."
+msgid "Release Group disambiguation comment."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:97
-msgid "**_releaselanguage**"
+msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:99
-msgid "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
+msgid ""
+"The date of the earliest release in the Release Group in the format YYYY-"
+"MM-DD. This is intended to provide, for example, the release date of the "
+"vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:103
-msgid "**_secondaryreleasetype**"
+msgid ""
+"This is the same information provided by default in the ``originaldate`` "
+"tag."
 msgstr ""
 
 #: ../../variables/variables_basic.rst:105
-msgid "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
+msgid "**_releaselanguage**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:107
+msgid ""
+"Release Language as per `ISO 639-3 "
+"<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:111
+msgid "**_secondaryreleasetype**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:113
+msgid ""
+"Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
+" dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
+"spokenword)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:115
 msgid "**_totalalbumtracks**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:117
 msgid "The total number of tracks across all discs of this release."
 msgstr ""
+

--- a/_locale/pt_BR/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/pt_BR/LC_MESSAGES/variables/variables_basic.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-18 09:49-0600\n"
+"POT-Creation-Date: 2022-01-26 13:55-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: pt_BR\n"
@@ -117,129 +117,139 @@ msgid ""
 msgstr ""
 
 #: ../../variables/variables_basic.rst:51
-msgid "**_pregap**"
+msgid "**_musicbrainz_tracknumber**"
 msgstr ""
 
 #: ../../variables/variables_basic.rst:53
+msgid ""
+"The track number written as on the MusicBrainz release, such as vinyl "
+"numbering (A1, A2...)."
+msgstr ""
+
+#: ../../variables/variables_basic.rst:55
+msgid "**_pregap**"
+msgstr ""
+
+#: ../../variables/variables_basic.rst:57
 msgid ""
 "Set to 1 if the track is a \"`pregap track "
 "<https://musicbrainz.org/doc/Terminology#hidden_track>`_\". (*since "
 "Picard 1.3.1*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:57
+#: ../../variables/variables_basic.rst:61
 msgid "**_primaryreleasetype**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:59
+#: ../../variables/variables_basic.rst:63
 msgid "Release Group Primary type (i.e.: album, single, ep, broadcast, or other)."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:61
+#: ../../variables/variables_basic.rst:65
 msgid "**_rating**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:63
+#: ../../variables/variables_basic.rst:67
 msgid "Rating 0-5 by MusicBrainz users."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:65
+#: ../../variables/variables_basic.rst:69
 msgid "**_recording_firstreleasedate**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:67
+#: ../../variables/variables_basic.rst:71
 msgid ""
 "The date of the earliest recording for a track in the format YYYY-MM-DD."
 "  (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:69
+#: ../../variables/variables_basic.rst:73
 msgid "**_releaseannotation**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:71
+#: ../../variables/variables_basic.rst:75
 msgid "The annotation comment for the release. (*since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid "**_releasecomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "**_releasecountries**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid ""
 "This provides the complete list of release countries for the release as a"
 " multi-value variable. (*since Picard 2.3.1*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid "**_releasegroup**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:83
+#: ../../variables/variables_basic.rst:87
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but "
 "can be different."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid "**_releasegroupcomment**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid "Release Group disambiguation comment."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid "**_releasegroup_firstreleasedate**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:91
+#: ../../variables/variables_basic.rst:95
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-"
 "MM-DD. This is intended to provide, for example, the release date of the "
 "vinyl version of what you have on CD. (*Since Picard 2.6*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "This is the same information provided by default in the ``originaldate`` "
 "tag."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:97
+#: ../../variables/variables_basic.rst:101
 msgid "**_releaselanguage**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid ""
 "Release Language as per `ISO 639-3 "
 "<https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:103
+#: ../../variables/variables_basic.rst:107
 msgid "**_secondaryreleasetype**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:105
+#: ../../variables/variables_basic.rst:109
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation,"
 " dj-mix, interview, live, mixtape/street, remix, soundtrack, or "
 "spokenword)."
 msgstr ""
 
-#: ../../variables/variables_basic.rst:107
+#: ../../variables/variables_basic.rst:111
 msgid "**_totalalbumtracks**"
 msgstr ""
 
-#: ../../variables/variables_basic.rst:109
+#: ../../variables/variables_basic.rst:113
 msgid "The total number of tracks across all discs of this release."
 msgstr ""
 

--- a/variables/variables_basic.rst
+++ b/variables/variables_basic.rst
@@ -48,6 +48,10 @@ These variables are populated from MusicBrainz data for most releases, without a
     the disc ids attached to that medium. For example, the list provided for Disc 1 of a three CD set will not include the disc ids attached to discs 2
     and 3 of the set.
 
+**_musicbrainz_tracknumber**
+
+    The track number written as on the MusicBrainz release, such as vinyl numbering (A1, A2...).
+
 **_pregap**
 
    Set to 1 if the track is a "`pregap track <https://musicbrainz.org/doc/Terminology#hidden_track>`_". (*since Picard 1.3.1*)

--- a/variables/variables_basic.rst
+++ b/variables/variables_basic.rst
@@ -66,6 +66,10 @@ These variables are populated from MusicBrainz data for most releases, without a
 
     Rating 0-5 by MusicBrainz users.
 
+**_recording_comment**
+
+   The disambiguation comment for the recording associated with a track.
+
 **_recording_firstreleasedate**
 
    The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The `%_musicbrainz_tracknumber%` variable was never included in the documentation.

**EDIT:** The `%_recording_comment%` was also missing.

### Description of the Change

Add documentation for the `%_musicbrainz_tracknumber%` variable.

**EDIT:** Also add the definition for the `%_recording_comment%` valiable.

### Additional Action Required

None.
