### PR TITLE
PICARD-2408: Add documentation of the use of EAC / XLD logs for CD lookup

### DIFF
--- a/epub.rst
+++ b/epub.rst
@@ -60,6 +60,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
 
    General Recommendations <workflows/workflows>
    workflows/workflow_cd
+   workflows/workflow_extractor_log
    workflows/workflow_album
    workflows/workflow_metadata
    workflows/workflow_no_info

--- a/index.rst
+++ b/index.rst
@@ -60,6 +60,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
 
    General Recommendations <workflows/workflows>
    workflows/workflow_cd
+   workflows/workflow_extractor_log
    workflows/workflow_album
    workflows/workflow_metadata
    workflows/workflow_no_info

--- a/usage/attach_disc_id.rst
+++ b/usage/attach_disc_id.rst
@@ -16,7 +16,11 @@ The steps to follow to submit a disc id are:
 **1. Lookup the CD**
 
    Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
-   The CD TOC will be calculated and sent to MusicBrainz, and a list of matching releases will be displayed.
+   The CD toc will be calculated and sent to MusicBrainz. Alternately, you can use an EAC or XLD ripper log file
+   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD log file..."` command. This
+   will open a file browser dialog to allow you to select the log file to process. Either method will query the
+   MusicBrainz database and display a list of matching releases.
+
 
    .. image:: images/cd_lookup_1.png
       :width: 100%

--- a/usage/attach_disc_id.rst
+++ b/usage/attach_disc_id.rst
@@ -16,8 +16,8 @@ The steps to follow to submit a disc id are:
 **1. Lookup the CD**
 
    Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
-   The CD toc will be calculated and sent to MusicBrainz. Alternately, you can use an EAC or XLD ripper log file
-   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD log file..."` command. This
+   The CD toc will be calculated and sent to MusicBrainz. Alternately, you can use an EAC, XLD or Whipper ripper log file
+   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper log file..."` command. This
    will open a file browser dialog to allow you to select the log file to process. Either method will query the
    MusicBrainz database and display a list of matching releases.
 

--- a/usage/retrieve_lookup_cd_steps.txt
+++ b/usage/retrieve_lookup_cd_steps.txt
@@ -3,8 +3,8 @@
 The steps to follow to :index:`lookup a CD <lookup cd>` are:
 
 1. Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
-   The CD toc will be calculated and sent to MusicBrainz. Alternately, you can use an EAC or XLD ripper log file
-   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD log file..."` command. This
+   The CD toc will be calculated and sent to MusicBrainz. Alternately, you can use an EAC, XLD or Whipper ripper log file
+   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper log file..."` command. This
    will open a file browser dialog to allow you to select the log file to process. Either method will query the
    MusicBrainz database and display a list of matching releases.
 

--- a/usage/retrieve_lookup_cd_steps.txt
+++ b/usage/retrieve_lookup_cd_steps.txt
@@ -3,7 +3,10 @@
 The steps to follow to :index:`lookup a CD <lookup cd>` are:
 
 1. Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
-   The CD toc will be calculated and sent to MusicBrainz, and a list of matching releases will be displayed.
+   The CD toc will be calculated and sent to MusicBrainz. Alternately, you can use an EAC or XLD ripper log file
+   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD log file..."` command. This
+   will open a file browser dialog to allow you to select the log file to process. Either method will query the
+   MusicBrainz database and display a list of matching releases.
 
    .. image:: images/cd_lookup_1.png
       :width: 100%

--- a/workflows/workflow_cd.rst
+++ b/workflows/workflow_cd.rst
@@ -10,7 +10,8 @@ up the release.
 **1. Rip the CD to music files**
 
    Extract the music filed from the CD using your favorite ripping program (e.g.: `Exact Audio Copy
-   <http://exactaudiocopy.de/>`_ for Windows or `Whipper <https://github.com/whipper-team/whipper>`_ for Linux).
+   <http://exactaudiocopy.de/>`_ for Windows, `X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_
+   for macOS, or `Whipper <https://github.com/whipper-team/whipper>`_ for Linux).
    The format for the output files depends on your personal preference and the formats supported by your player.
    A popular format is FLAC, which is a compressed lossless format.
 
@@ -23,11 +24,14 @@ up the release.
 
 **3. Select the correct release**
 
-   If there is only one release that matches the disc id for your disc, it will be loaded automatically.  Before
-   proceeding, please check to ensure that it properly matches your CD (e.g.: release country, date and label,
-   catalog number, barcode, media type, and cover art).  This is especially important if you are going to submit
-   any information such as disc id or AcoustID fingerprints.
+   A list of all releases matching the toc of the CD will be displayed for selection, with an option to submit
+   the disc id if none of the releases are a match to your CD.  Before proceeding, please check to ensure that
+   the release you select properly matches your CD (e.g.: release country, date and label, catalog number,
+   barcode, media type, and cover art).  This is especially important if you are going to submit any
+   information such as acoustic features to AcousticBrainz or AcoustID fingerprints.
 
+   .. image:: /usage/images/cd_lookup_1.png
+      :width: 100%
 
 **4. Load the files**
 

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -1,7 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
-:index:`When the ripper log file is available <workflows; EAC log, workflows; XLD log>`
-=======================================================================================
+:index:`When the ripper log file is available <workflows; EAC log, workflows; XLD log, EAC; lookup log, XLD; lookup log>`
+=========================================================================================================================
 
 This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
 file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows and

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -1,0 +1,66 @@
+.. MusicBrainz Picard Documentation Project
+
+:index:`When the ripper log file is available <workflows; EAC log, workflows; XLD log>`
+=======================================================================================
+
+This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
+file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows and
+`X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS.  Because the log files of these
+rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
+the CD. As with reading the CD itself, this method provides the greatest chance of tagging your music files with
+the most accurate match from the MusicBrainz database.  It is also one of the easier methods for looking up the
+release.
+
+**1. Lookup the CD on MusicBrainz**
+
+   Use the ripper log file to look up the release automatically by selecting the
+   :menuselection:`"Tools --> Lookup CD --> From EAC / XLD log file..."` command. This will open a file browser
+   dialog to allow you to select the log file to process. See the :doc:`/usage/retrieve_lookup_cd` section for
+   detailed instructions.
+
+
+**2. Select the correct release**
+
+   If there is only one release that matches the disc id for your disc, it will be loaded automatically.  Before
+   proceeding, please check to ensure that it properly matches your CD (e.g.: release country, date and label,
+   catalog number, barcode, media type, and cover art).  This is especially important if you are going to submit
+   any information such as disc id or AcoustID fingerprints.
+
+
+**3. Load the files**
+
+   Drag the files or folder from the browser to the "Unclustered Files" section in the left-hand pane.  You do not
+   need to scan or cluster them.
+
+
+**4. Match the files to the tracks on the release**
+
+   Drag the files from the left-hand pane and drop them on the release in the right-hand pane.  Check that each
+   track on the release is associated with only one file.  The release icon should turn gold.  See the
+   :doc:`/usage/match` section for details.
+
+
+**5. Verify the metadata and cover art**
+
+   Check that the metadata and cover art image for the release and tracks are what you want.  Adjust if required.
+   See the :doc:`/usage/coverart` section for details.
+
+
+**7. Save the files**
+
+   Save the files using the :menuselection:`"File --> Save"` command.  See the :doc:`/usage/save` section for details.
+
+
+**8. Calculate and submit AcoustID fingerprints**
+
+   :index:`This step is optional <acoustic fingerprint; submitting>`, but appreciated because it will help identify
+   the files for others to look up for tagging.
+
+   Select the album entry in the right-hand pane and calculate the AcoustID fingerprints using
+   :menuselection:`"Tools --> Generate AcoustID Fingerprints"`.  Once the fingerprints have been calculated, submit
+   them using :menuselection:`"Files --> Submit AcoustIDs"`.
+
+   .. note::
+
+      AcoustID fingerprints should only be submitted after the files have been tagged with MusicBrainz metadata, and you have
+      verified that the files have been matched to the correct track on the proper release.

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -4,8 +4,9 @@
 =========================================================================================================================
 
 This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
-file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows and
-`X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS.  Because the log files of these
+file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows,
+`X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS, and
+`Whipper <https://github.com/whipper-team/whipper>`_ for Linux.  Because the log files of these
 rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
 the CD. As with reading the CD itself, this method provides the greatest chance of tagging your music files with
 the most accurate match from the MusicBrainz database.  It is also one of the easier methods for looking up the
@@ -14,17 +15,21 @@ release.
 **1. Lookup the CD on MusicBrainz**
 
    Use the ripper log file to look up the release automatically by selecting the
-   :menuselection:`"Tools --> Lookup CD --> From EAC / XLD log file..."` command. This will open a file browser
-   dialog to allow you to select the log file to process. See the :doc:`/usage/retrieve_lookup_cd` section for
-   detailed instructions.
+   :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper log file..."` command. This will open a
+   file browser dialog to allow you to select the log file to process. See the :doc:`/usage/retrieve_lookup_cd`
+   section for detailed instructions.
 
 
 **2. Select the correct release**
 
-   If there is only one release that matches the disc id for your disc, it will be loaded automatically.  Before
-   proceeding, please check to ensure that it properly matches your CD (e.g.: release country, date and label,
-   catalog number, barcode, media type, and cover art).  This is especially important if you are going to submit
-   any information such as disc id or AcoustID fingerprints.
+   A list of all releases matching the toc of the CD will be displayed for selection, with an option to submit
+   the disc id if none of the releases are a match to your CD.  Before proceeding, please check to ensure that
+   the release you select properly matches your CD (e.g.: release country, date and label, catalog number,
+   barcode, media type, and cover art).  This is especially important if you are going to submit any
+   information such as acoustic features to AcousticBrainz or AcoustID fingerprints.
+
+   .. image:: /usage/images/cd_lookup_1.png
+      :width: 100%
 
 
 **3. Load the files**

--- a/workflows/workflows.rst
+++ b/workflows/workflows.rst
@@ -9,9 +9,10 @@ based on what are believed to be best practices.
 The scenarios covered include:
 
 1. :doc:`workflow_cd`
-2. :doc:`workflow_album`
-3. :doc:`workflow_metadata`
-4. :doc:`workflow_no_info`
+2. :doc:`workflow_extractor_log`
+3. :doc:`workflow_album`
+4. :doc:`workflow_metadata`
+5. :doc:`workflow_no_info`
 
 .. note::
 
@@ -26,6 +27,7 @@ The scenarios covered include:
       :hidden:
 
       workflow_cd
+      workflow_extractor_log
       workflow_album
       workflow_metadata
       workflow_no_info


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Changes in https://github.com/metabrainz/picard/pull/2048 added the ability to use an EAC or XLD ripper log file to lookup a release.

**EDIT:** Updated to include ability to use Whipper log files that was added in https://github.com/metabrainz/picard/pull/2056

### Description of the Change

Add documentation of the use of EAC / XLD / Whipper logs for CD lookup.

### Additional Action Required

Update translation files.
