### PR TITLE
Remove "musicbrainz_releasetrackid" from basic tag list

### DIFF
--- a/variables/tags_basic.rst
+++ b/variables/tags_basic.rst
@@ -187,13 +187,9 @@ several other more minor settings) by wrapping them between percent '%' symbols 
 
     Release Group's MusicBrainz Identifier.
 
-**musicbrainz_releasetrackid**
-
-    Release Track MusicBrainz Identifier. (*since Picard 1.3*)
-
 **musicbrainz_trackid**
 
-    MusicBrainz Identifier for the track.
+    Release Track MusicBrainz Identifier.
 
 **musicbrainz_workid**
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The internal tag name is "musicbrainz_trackid", not "musicbrainz_releasetrackid": "musicbrainz_trackid",". The latter is just the name written out to some formats, because "musicbrainz_trackid" has already been used for the recording ID for historic reasons

