### PR TITLE
Improve url remapping tests

### DIFF
--- a/404_template.html
+++ b/404_template.html
@@ -30,15 +30,17 @@
       var src_path_parts = src_path.split('/');
       var target_path = '';
       var target_url = '';
+      var has_language = false;
+      var has_version = false;
+      var language_changed = true;
+      var version_changed = true;
       var well_formed = true;
 
       var debug = false;
 
       const re_language = /^[a-z][a-z](_[A-Z][A-Z])?$/;
-      const re_version1 = /^v?[0-9][0-9\.]*$/;
-      const re_version2 = /^v[0-9][0-9\.]*$/;
-      const re_version3 = /^v([0-9]+\.[0-9]+)/;
-      const re_version4 = /^v?([0-9]+\.[0-9]+)/;
+      const re_version_a = /^v?[0-9][0-9\.]*$/;
+      const re_version_b = /^v?([0-9]+\.[0-9])/;
 
       const not_found = 'not_found.html';
 
@@ -64,6 +66,7 @@
             if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
+         has_language = true;
          var test_supported = test_supported_language(test_value)
          if (test_supported == "") {
             if (debug) { window.alert("Failed supported languages check.  Target language set to: " + target_language); }
@@ -72,16 +75,18 @@
          }
          target_language = test_supported;
          if (debug) { window.alert("Passed.  Target language set to: " + target_language); }
+         language_changed = false;
          return true;
       }
 
-      function is_rtd_version(test_version) {
-         if (debug) { window.alert("Testing RTD version: " + test_version); }
-         if (test_version.search(re_version1) < 0) {
+      function is_version(test_version) {
+         if (debug) { window.alert("Testing version: " + test_version); }
+         if (test_version.search(re_version_a) < 0) {
             if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
-         var arr = re_version4.exec(test_version);
+         has_version = true;
+         var arr = re_version_b.exec(test_version);
          var temp = arr[1];
          if (version_list.indexOf(temp) < 0) {
             if (debug) { window.alert("Failed supported versions check.  Version: " + temp); }
@@ -89,29 +94,7 @@
             return true;
          }
          target_version = '/v' + temp;
-         if (debug) { window.alert("Passed. Target version set to: " + target_version); }
-         return true;
-      }
-
-      function is_gh_version(test_version) {
-         if (debug) { window.alert("Testing GH version: " + test_version); }
-         if (test_version.search(re_version2) < 0) {
-            if (debug) { window.alert("Failed regular expression check."); }
-            return false;
-         }
-         var arr = re_version3.exec(test_version);
-         var temp = arr[1];
-         if (version_list.indexOf(temp) < 0) {
-            if (debug) { window.alert("Failed supported versions check.  Version: " + temp); }
-            target_version = '';
-            return true;
-         }
-         target_version = '/v' + temp;
-         if (target_version != '/' + test_version) {
-            if (debug) { window.alert("Target Version " + target_version + " != Test Version /" + test_version); }
-            if (debug) { window.alert("Changing well_formed to false."); }
-            well_formed = false;
-         }
+         if ((test_version == target_version) && (!has_language)) { version_changed = false; }
          if (debug) { window.alert("Passed. Target version set to: " + target_version); }
          return true;
       }
@@ -130,8 +113,8 @@
          }
       }
       else {
-         // Check for GitHub Pages style version number
-         if (is_gh_version(src_path_parts[counter])) {
+         // Check for version number
+         if (is_version(src_path_parts[counter])) {
             counter += 1;
          }
 
@@ -160,8 +143,7 @@
                   counter += 1;
                }
                else {
-                  if (is_rtd_version(src_path_parts[counter])) {
-                     well_formed = false;
+                  if (is_version(src_path_parts[counter])) {
                      counter += 1;
                   }
                }
@@ -193,6 +175,7 @@
 
             // Build the redirection target url
             target_url = src_protocol + '//' + src_host + target_version + '/' + target_language;
+            if ((language_changed) || (version_changed)) { well_formed = false; }
             if ((well_formed) || (target_url + target_path == window.location)) {
                if (debug) {
                   if (well_formed) {

--- a/404_template.html
+++ b/404_template.html
@@ -39,8 +39,8 @@
       var debug = false;
 
       const re_language = /^[a-z][a-z](_[A-Z][A-Z])?$/;
-      const re_version_a = /^[vV]?[0-9][0-9\.]*$/;
-      const re_version_b = /^[vV]?([0-9]+\.[0-9]+)/;
+      const re_version_a = /^[vV]?[0-9\.]+$/;
+      const re_version_b = /^[vV]?([0-9]+\.[0-9]+).*$/;
 
       const not_found = 'not_found.html';
 
@@ -103,6 +103,10 @@
          }
          has_version = true;
          var arr = re_version_b.exec(test_version);
+         if (!arr) {
+            if (debug) { window.alert("Failed missing major or minor versions check."); }
+            return true;
+         }
          var temp = arr[1];
          if (version_list.indexOf(temp) < 0) {
             if (debug) { window.alert("Failed supported versions check.  Version: " + temp); }

--- a/404_template.html
+++ b/404_template.html
@@ -39,8 +39,8 @@
       var debug = false;
 
       const re_language = /^[a-z][a-z](_[A-Z][A-Z])?$/;
-      const re_version_a = /^v?[0-9][0-9\.]*$/;
-      const re_version_b = /^v?([0-9]+\.[0-9]+)/;
+      const re_version_a = /^[vV]?[0-9][0-9\.]*$/;
+      const re_version_b = /^[vV]?([0-9]+\.[0-9]+)/;
 
       const not_found = 'not_found.html';
 

--- a/404_template.html
+++ b/404_template.html
@@ -60,6 +60,7 @@
       }
 
       function is_language(test_language) {
+         // Returning true will drop this item from the path
          var test_value = test_language.replace("-", "_");
          if (debug) { window.alert("Testing language: " + test_language); }
          if (test_value.search(re_language) < 0) {
@@ -70,7 +71,6 @@
          var test_supported = test_supported_language(test_value)
          if (test_supported == "") {
             if (debug) { window.alert("Failed supported languages check.  Target language set to: " + target_language); }
-            // Returning true will drop this item from the path
             return true;
          }
          target_language = test_supported;
@@ -80,7 +80,23 @@
       }
 
       function is_version(test_version) {
+         // Returning true will drop this item from the path
          if (debug) { window.alert("Testing version: " + test_version); }
+
+         // Check for ReadTheDocs style version number
+         if (test_version.toLowerCase() == 'latest') {
+            has_version = true;
+            target_version = '';
+            if (debug) { window.alert("Passed. Target version set to blank."); }
+            return true;
+         }
+         if (test_version.toLowerCase() == 'stable') {
+            has_version = true;
+            target_version = '/v' + stable_version;
+            if (debug) { window.alert("Passed. Target version set to: " + target_version); }
+            return true;
+         }
+
          if (test_version.search(re_version_a) < 0) {
             if (debug) { window.alert("Failed regular expression check."); }
             return false;
@@ -90,7 +106,6 @@
          var temp = arr[1];
          if (version_list.indexOf(temp) < 0) {
             if (debug) { window.alert("Failed supported versions check.  Version: " + temp); }
-            // Returning true will drop this item from the path
             return true;
          }
          target_version = '/v' + temp;
@@ -123,6 +138,13 @@
             counter += 1;
          }
 
+         // Recheck for version number to accommodate version entered after language
+         if (!has_version) {
+            if (is_version(src_path_parts[counter])) {
+               counter += 1;
+            }
+         }
+
          var anchor_test = document.URL.split('#');
          if (debug) { window.alert('Performing anchor test.\n\nLength: ' + anchor_test.length + "\nLast Part: " + anchor_test[anchor_test.length - 1]); }
          if ((anchor_test.length > 1) && (anchor_test[anchor_test.length - 1] == "redirected")) {
@@ -130,31 +152,6 @@
             if (debug) { window.alert('Page has already been redirected.\n\nOld URL: ' + window.location + "\nNew URL: " + target_url); }
          }
          else {
-            // Check for ReadTheDocs style version number
-            if (src_path_parts[counter] == 'latest') {
-               well_formed = false;
-               target_version = '';
-               counter += 1;
-            }
-            else {
-               if (src_path_parts[counter] == 'stable') {
-                  well_formed = false;
-                  target_version = '/v' + stable_version;
-                  counter += 1;
-               }
-               else {
-                  if (is_version(src_path_parts[counter])) {
-                     counter += 1;
-                  }
-               }
-            }
-
-            // Check for language identifier
-            if (is_language(src_path_parts[counter])) {
-               counter += 1;
-               well_formed = false;
-            }
-
             // Patch to redirect to new location of scripting documentation
             if (src_path_parts[counter] == 'scripting.html') {
                target_path += '/extending';

--- a/404_template.html
+++ b/404_template.html
@@ -40,7 +40,7 @@
 
       const re_language = /^[a-z][a-z](_[A-Z][A-Z])?$/;
       const re_version_a = /^v?[0-9][0-9\.]*$/;
-      const re_version_b = /^v?([0-9]+\.[0-9])/;
+      const re_version_b = /^v?([0-9]+\.[0-9]+)/;
 
       const not_found = 'not_found.html';
 


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [x] Other

### Reason for the Change

Improve url remapping to try to avoid 404s.  Current tests and remapping did not properly handle some cases.

### Description of the Change

Improve automatic url remapping:

- Test and correct invalid version number such as 'v2.6.3' rather than 'v2.6' and to add missing 'v' if necessary.  Automatically redirect to the latest version if an invalid `major.minor` such as '99.99' is provided when the latest release is '2.7'.

- Automatically remap ReadTheDocs version specifiers 'latest' and 'stable' to the appropriate versions.

- Automatically try to serve a language matching the preferred languages in the user's browser settings if there is no language specified in the url.  For example, `https://picard-docs.musicbrainz.org/variables/tags_basic.html` will be served as `https://picard-docs.musicbrainz.org/fr/variables/tags_basic.html` if the user's browser language preference is French.

- Automatically replace unsupported languages with the default language.  For example, `https://picard-docs.musicbrainz.org/tr/variables/tags_basic.html` will be served as `https://picard-docs.musicbrainz.org/en/variables/tags_basic.html` if there is no Turkish translation available.

- Automatically correct language and version number entered in the wrong order (should be version before language).  For example, `https://picard-docs.musicbrainz.org/en/2.63/variables/tags_basic.html` will be corrected to `https://picard-docs.musicbrainz.org/v2.6/en/variables/tags_basic.html`.

### Additional Action Required

None.
