### PR TITLE
Add fre:ac and dBpoweramp to ripper logs parsed

### DIFF
--- a/faq/faq_file_formats.rst
+++ b/faq/faq_file_formats.rst
@@ -45,6 +45,21 @@ What formats will Picard support?
 Picard is intended to eventually support all formats (including fingerprinting), but this is a complex (arguably never-ending) process,
 and will take some time.
 
+.. _faq_supported_rippers:
+
+What rippers are supported for looking up from logs?
+----------------------------------------------------
+
+As of version 2.8, Picard supports the use of log files produced by popular CD file rippers for looking up a release. Because the log
+files of these rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
+the CD itself.  The supported rippers include:
+
+- `dBpoweramp <https://dbpoweramp.com/>`_ for macOS and Windows
+- `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows
+- `fre:ac <https://www.freac.org>`_ for Linux, macOS, Windows and others
+- `Whipper <https://github.com/whipper-team/whipper>`_ for Linux
+- `X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS
+
 
 Which tags can Picard write to my files?
 -------------------------------------------

--- a/faq/faq_file_formats.rst
+++ b/faq/faq_file_formats.rst
@@ -50,7 +50,7 @@ and will take some time.
 What rippers are supported for looking up from logs?
 ----------------------------------------------------
 
-As of version 2.8, Picard supports the use of log files produced by popular CD file rippers for looking up a release. Because the log
+As of version 2.9, Picard supports the use of log files produced by popular CD file rippers for looking up a release. Because the log
 files of these rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
 the CD itself.  The supported rippers include:
 

--- a/usage/retrieve.rst
+++ b/usage/retrieve.rst
@@ -14,15 +14,16 @@ There are basically four main methods used to retrieve album information from th
 
 .. only:: latex
 
-   Lookup CD
-   ---------
+   Lookup CD or Ripper Log
+   -----------------------
 
 .. only:: html
 
-   :doc:`Lookup CD <retrieve_lookup_cd>`
+   :doc:`Lookup CD or Ripper Log <retrieve_lookup_cd>`
 
 This is the preferred method of automatically identifying the album to retrieve, and
-should be used when you have the CD available.  Typically this would be used right after ripping the
+should be used when you have the CD or :ref:`supported ripper log <faq_supported_rippers>` available.
+Typically this would be used right after ripping the
 audio files from the CD.  When initiated, the table of contents (TOC) is read from the CD and a request
 is sent to MusicBrainz to return a list of the releases that match the TOC.  If there are any matches,
 then they will be listed for you to select the one to use.  If there are no matches or none of the

--- a/usage/retrieve_lookup_cd.rst
+++ b/usage/retrieve_lookup_cd.rst
@@ -1,6 +1,6 @@
 .. MusicBrainz Picard Documentation Project
 
-Lookup CD
-=========
+Lookup CD or Ripper Log
+=======================
 
 .. include:: retrieve_lookup_cd_steps.txt

--- a/usage/retrieve_lookup_cd_steps.txt
+++ b/usage/retrieve_lookup_cd_steps.txt
@@ -3,8 +3,8 @@
 The steps to follow to :index:`lookup a CD <lookup; cd, lookup; ripper log>` are:
 
 1. Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
-   The CD TOC will be calculated and sent to MusicBrainz. Alternately, you can use an EAC, XLD or Whipper ripper log file
-   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper / fre:ac log file..."` command. This
+   The CD TOC will be calculated and sent to MusicBrainz. Alternately, you can use a :doc:`supported ripper log file </workflows/workflow_extractor_log>`
+   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From CD ripper log file..."` command. This
    will open a file browser dialog to allow you to select the log file to process. Either method will query the
    MusicBrainz database and display a list of matching releases.
 

--- a/usage/retrieve_lookup_cd_steps.txt
+++ b/usage/retrieve_lookup_cd_steps.txt
@@ -3,7 +3,7 @@
 The steps to follow to :index:`lookup a CD <lookup; cd, lookup; ripper log>` are:
 
 1. Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
-   The CD TOC will be calculated and sent to MusicBrainz. Alternately, you can use a :doc:`supported ripper log file </workflows/workflow_extractor_log>`
+   The CD TOC will be calculated and sent to MusicBrainz. Alternately, you can use a :ref:`supported ripper log file <faq_supported_rippers>`
    to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From CD ripper log file..."` command. This
    will open a file browser dialog to allow you to select the log file to process. Either method will query the
    MusicBrainz database and display a list of matching releases.

--- a/usage/retrieve_lookup_cd_steps.txt
+++ b/usage/retrieve_lookup_cd_steps.txt
@@ -1,10 +1,10 @@
 .. MusicBrainz Picard Documentation Project
 
-The steps to follow to :index:`lookup a CD <lookup cd>` are:
+The steps to follow to :index:`lookup a CD <lookup; cd, lookup; ripper log>` are:
 
 1. Make sure the CD is inserted in the drive, and select :menuselection:`"Tools --> Lookup CD... --> (drive to use)"`.
    The CD TOC will be calculated and sent to MusicBrainz. Alternately, you can use an EAC, XLD or Whipper ripper log file
-   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper log file..."` command. This
+   to lookup the CD using the :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper / fre:ac log file..."` command. This
    will open a file browser dialog to allow you to select the log file to process. Either method will query the
    MusicBrainz database and display a list of matching releases.
 

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -1,12 +1,21 @@
 .. MusicBrainz Picard Documentation Project
 
-:index:`When the ripper log file is available <workflows; EAC log, workflows; XLD log, EAC; lookup log, XLD; lookup log>`
-=========================================================================================================================
+.. index::
+   single: workflows; ripper log
+   single: lookup; ripper log
+   single: EAC; lookup log
+   single: XLD; lookup log
+   single: Whipper; lookup log
+   single: fre:ac; lookup log
+
+When the ripper log file is available
+=====================================
 
 This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
 file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows,
-`X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS, and
-`Whipper <https://github.com/whipper-team/whipper>`_ for Linux.  Because the log files of these
+`X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS,
+`Whipper <https://github.com/whipper-team/whipper>`_ for Linux, and
+`fre:ac <https://www.freac.org>`_ for multiple platforms.  Because the log files of these
 rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
 the CD. As with reading the CD itself, this method provides the greatest chance of tagging your music files with
 the most accurate match from the MusicBrainz database.  It is also one of the easier methods for looking up the
@@ -15,7 +24,7 @@ release.
 **1. Lookup the CD on MusicBrainz**
 
    Use the ripper log file to look up the release automatically by selecting the
-   :menuselection:`"Tools --> Lookup CD --> From EAC / XLD / Whipper log file..."` command. This will open a
+   :menuselection:`"Tools --> Lookup CD --> EAC / XLD / Whipper / fre:ac log files..."` command. This will open a
    file browser dialog to allow you to select the log file to process. See the :doc:`/usage/retrieve_lookup_cd`
    section for detailed instructions.
 

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -3,20 +3,11 @@
 :index:`When the ripper log file is available <workflows; ripper log, lookup; ripper log, EAC; lookup log, XLD; lookup log, Whipper; lookup log, fre:ac; lookup log, dBpoweramp; lookup log>`
 =============================================================================================================================================================================================
 
-This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
-file rippers:
-
-- `dBpoweramp <https://dbpoweramp.com/>`_ for macOS and Windows
-- `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows
-- `fre:ac <https://www.freac.org>`_ for Linux, macOS, Windows and others
-- `Whipper <https://github.com/whipper-team/whipper>`_ for Linux
-- `X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS
-
-Because the log files of these
-rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
-the CD. As with reading the CD itself, this method provides the greatest chance of tagging your music files with
-the most accurate match from the MusicBrainz database.  It is also one of the easier methods for looking up the
-release.
+This option was added to Picard in version 2.8, and supports the use of log files produced by :ref:`supported
+popular CD file rippers <faq_supported_rippers>`. Because the log files of these rippers contain sufficient
+information to generate the CD table of contents they can be used in place of reading the CD. As with reading
+the CD itself, this method provides the greatest chance of tagging your music files with the most accurate
+match from the MusicBrainz database.  It is also one of the easier methods for looking up the release.
 
 **1. Lookup the CD on MusicBrainz**
 

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -1,13 +1,18 @@
 .. MusicBrainz Picard Documentation Project
 
-:index:`When the ripper log file is available <workflows; ripper log, lookup; ripper log, EAC; lookup log, XLD; lookup log, Whipper; lookup log, fre:ac; lookup log>`
-=====================================================================================================================================================================
+:index:`When the ripper log file is available <workflows; ripper log, lookup; ripper log, EAC; lookup log, XLD; lookup log, Whipper; lookup log, fre:ac; lookup log, dBpoweramp; lookup log>`
+=============================================================================================================================================================================================
 
 This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
-file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows,
-`X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS,
-`Whipper <https://github.com/whipper-team/whipper>`_ for Linux, and
-`fre:ac <https://www.freac.org>`_ for multiple platforms.  Because the log files of these
+file rippers:
+
+- `dBpoweramp <https://dbpoweramp.com/>`_ for macOS and Windows
+- `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows
+- `fre:ac <https://www.freac.org>`_ for Linux, macOS, Windows and others
+- `Whipper <https://github.com/whipper-team/whipper>`_ for Linux
+- `X Lossless Decoder (XLD) <https://tmkk.undo.jp/xld/index_e.html>`_ for macOS
+
+Because the log files of these
 rippers contain sufficient information to generate the CD table of contents they can be used in place of reading
 the CD. As with reading the CD itself, this method provides the greatest chance of tagging your music files with
 the most accurate match from the MusicBrainz database.  It is also one of the easier methods for looking up the
@@ -16,7 +21,7 @@ release.
 **1. Lookup the CD on MusicBrainz**
 
    Use the ripper log file to look up the release automatically by selecting the
-   :menuselection:`"Tools --> Lookup CD --> EAC / XLD / Whipper / fre:ac log files..."` command. This will open a
+   :menuselection:`"Tools --> Lookup CD --> From CD ripper log file..."` command. This will open a
    file browser dialog to allow you to select the log file to process. See the :doc:`/usage/retrieve_lookup_cd`
    section for detailed instructions.
 

--- a/workflows/workflow_extractor_log.rst
+++ b/workflows/workflow_extractor_log.rst
@@ -1,15 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
-.. index::
-   single: workflows; ripper log
-   single: lookup; ripper log
-   single: EAC; lookup log
-   single: XLD; lookup log
-   single: Whipper; lookup log
-   single: fre:ac; lookup log
-
-When the ripper log file is available
-=====================================
+:index:`When the ripper log file is available <workflows; ripper log, lookup; ripper log, EAC; lookup log, XLD; lookup log, Whipper; lookup log, fre:ac; lookup log>`
+=====================================================================================================================================================================
 
 This option was added to Picard in version 2.8, and supports the use of log files produced by the popular CD
 file rippers `Exact Audio Copy (EAC) <http://exactaudiocopy.de/>`_ for Windows,


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Parsing of **fre:ac** logs is being added to version 3 of Picard in https://github.com/metabrainz/picard/pull/2158, and **dBpoweramp** logs added in https://github.com/metabrainz/picard/pull/2151#event-7453440343.

### Description of the Change

Update the list of ripper logs that Picard can process for lookup.  ~Also some minor refactoring to clarify the index entries for the page.~

**Note:** The restructuring was reverted because Sphinx does not include index items entered in an `index` **directive** in the translation POT and PO files.  Only entries from an `index` **role** are included in the translation files.  This was reported in https://github.com/sphinx-doc/sphinx/issues/976 and the issue was closed; however, the issue does not appear to have been corrected.

### Additional Action Required

Once merged, the translation files will need to be updated.
