### PR TITLE
Single instance operation and executable command processing

### DIFF
--- a/about_picard/acknowledgements.rst
+++ b/about_picard/acknowledgements.rst
@@ -28,11 +28,13 @@ Contributors include (in alphabetic surname order):
 - Akash Nagaraj
 - Frederik "Freso" S. Olesen
 - Theodore Fabian Rudy
+- skelly37
 - Sophist
 - Bob Swift
 - Akshat Tiwari
 - Philipp Wolfer
 - Shadab Zafar
+
 
 .. note::
 

--- a/appendices/command_line.rst
+++ b/appendices/command_line.rst
@@ -17,7 +17,7 @@ where the options are:
 
 .. option:: -c CONFIG_FILE, --config-file CONFIG_FILE
 
-   location of the configuration file to use (implies ``--stand-alone-instance``)
+   location of the configuration file to use
 
 .. option:: -d, --debug
 
@@ -37,11 +37,11 @@ where the options are:
 
 .. option:: -P, --no-plugins
 
-   do not load any plugins (starts a stand-alone instance)
+   do not load any plugins
 
 .. option:: -s, --stand-alone-instance
 
-   force Picard to create a new, stand-alone instance (see :doc:`/usage/command_processing` for more information)
+   force Picard to create a new, stand-alone instance
 
 .. option:: -v, --version
 

--- a/appendices/command_line.rst
+++ b/appendices/command_line.rst
@@ -7,7 +7,7 @@ Picard can be started from the command line with the following arguments:
 
 .. code::
 
-   picard [-h] [-c CONFIG_FILE] [-d] [-N] [-P] [-v] [-V] [FILE [FILE ...]]
+   picard [-h] [-c CONFIG_FILE] [-d] [-N] [-P] [-v] [-V] [FILE_OR_URL [FILE_OR_URL ...]]
 
 where the options are:
 
@@ -17,7 +17,7 @@ where the options are:
 
 .. option:: -c CONFIG_FILE, --config-file CONFIG_FILE
 
-   location of the configuration file to use
+   location of the configuration file to use (implies ``--stand-alone-instance``)
 
 .. option:: -d, --debug
 
@@ -33,7 +33,11 @@ where the options are:
 
 .. option:: -P, --no-plugins
 
-   do not load any plugins
+   do not load any plugins (starts a stand-alone instance)
+   
+.. option:: -s, --stand-alone-instance
+                        
+   force Picard to create a new, stand-alone instance
 
 .. option:: -v, --version
 
@@ -43,9 +47,9 @@ where the options are:
 
    display the long version information and exit
 
-.. describe:: FILE
+.. describe:: FILE_OR_URL
 
-   the file or files to load
+   the file(s), URL(s) and MBID(s) to load
 
 .. raw:: latex
 

--- a/appendices/command_line.rst
+++ b/appendices/command_line.rst
@@ -7,7 +7,7 @@ Picard can be started from the command line with the following arguments:
 
 .. code::
 
-   picard [-h] [-c CONFIG_FILE] [-d] [-N] [-P] [-v] [-V] [FILE_OR_URL [FILE_OR_URL ...]]
+   picard [-h] [-c CONFIG_FILE] [-d] [-N] [-P] [-s] [-v] [-V] [FILE_OR_URLs] [-e COMMANDs]
 
 where the options are:
 
@@ -23,6 +23,10 @@ where the options are:
 
    enable debug-level logging
 
+.. option:: -e COMMAND, --exec COMMAND
+
+   execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` for more information)
+
 .. option:: -M, --no-player
 
    disable built-in media player
@@ -34,10 +38,10 @@ where the options are:
 .. option:: -P, --no-plugins
 
    do not load any plugins (starts a stand-alone instance)
-   
+
 .. option:: -s, --stand-alone-instance
-                        
-   force Picard to create a new, stand-alone instance
+
+   force Picard to create a new, stand-alone instance (see :doc:`/usage/command_processing` for more information)
 
 .. option:: -v, --version
 
@@ -49,7 +53,17 @@ where the options are:
 
 .. describe:: FILE_OR_URL
 
-   the file(s), URL(s) and MBID(s) to load
+   one or more files, directories, URLs and MBIDs to load
+
+   .. note::
+
+      Files and directories are specified including the path (either absolute or relative) to the file or directory, and may include drive specifiers.
+      They can also be specified using the ``file://`` prefix.
+      URLs are specified by using either the ``http://`` or ``https://`` prefix.
+      MBIDs are specified in the format ``mbid://<entity_type>/<mbid>`` where ``<entity_type>`` is one of "release", "artist"
+      or "track" and ``<mbid>`` is the MusicBrainz Identifier of the entity.
+
+      If a specified item contains a space, it must be enclosed in quotes such as ``"/home/user/music/my song.mp3"``.
 
 .. raw:: latex
 

--- a/epub.rst
+++ b/epub.rst
@@ -32,6 +32,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
    workflows/workflows
    usage/other
    usage/option_profiles
+   usage/command_processing
    extending/extending
    troubleshooting/pdf_troubleshooting
    faq/faq

--- a/getting_started/pdf_starting.rst
+++ b/getting_started/pdf_starting.rst
@@ -10,5 +10,6 @@ including installation and some basic information about the user interface.
    :hidden:
 
    download
+   starting
    screen_main
    status_icons

--- a/getting_started/starting.rst
+++ b/getting_started/starting.rst
@@ -10,29 +10,34 @@ be started from a command line prompt with some overrides available.  From the c
 you can also specify files or directories to load into Picard for processing.  Please see
 :doc:`/appendices/command_line` for more details about the available options.
 
-As of version 3, Picard will try to only run a single instance of the program at a time.
-When the program is started, it checks to see if there is another instance of that version, configuration file and plugin startup status ``-P``
-already running.  If the same version is already running, any files or directories specified
-on the command line of the new instance will be passed to the already running instance for
-processing and the new duplicate instance will be shut down.  This allows batch processing
-of files to be initiated automatically from other processes.  If there is no instance of that
-version already running, Picard will start normally.  Additionally, Picard can be started in
-"stand-alone" mode, in which case it neither sends information to an already running instance
-nor accepts information from another instance.
+As of version 2.9, Picard will try to only run a single instance of the program at a time.
+When the program is started, it checks to see if there is another instance of that version,
+configuration file and plugin startup status ``-P`` already running.  If the same version
+is already running, any files or directories specified on the command line of the new
+instance, along with any executable commands specified with the ``-e`` or ``-exec`` options
+will be passed to the already running instance for processing and the new duplicate instance
+will be shut down.  This allows batch processing of files to be initiated automatically from
+other processes.  If there is no instance of that version already running, Picard will start
+normally.
+
+Additionally, Picard can be started in "stand-alone" mode, in which case it neither sends
+information to an already running instance nor accepts information from another instance.
 
 Instances started with command-line argument ``-s / --stand-alone`` always start as stand-alone.
 
 If there is already an instance running when another instance is started that doesn't result in a
 stand-alone instance, any of the command-line overrides ``-d / --debug``, ``-M / --no-player``
 or ``-N / -no-restore`` of the new duplicate instance will be ignored, and only the specified
-files or directories (if any) will be passed to the running instance for processing.  Similarly,
-if a primary instance has been started with any of these overrides specified on the command line,
-starting a subsequent instance of that version without the override will not modify the user
-interface settings of the currently running instance.
+files or directories and executable commands (if any) will be passed to the running instance for
+processing.  Similarly, if a primary instance has been started with any of these overrides
+specified on the command line, starting a subsequent instance of that version without the override
+will not modify the user interface settings of the currently running instance.
 
 All instances started with the ``-h / --help``, ``-v / --version`` or ``-V / --long-version``
 command line arguments will always output the requested product information and exit, regardless of
 whether or not another instance is running.
+
+Please refer to the :doc:`/usage/command_processing` section for more information.
 
 .. raw:: latex
 

--- a/getting_started/starting.rst
+++ b/getting_started/starting.rst
@@ -1,0 +1,39 @@
+.. MusicBrainz Picard Documentation Project
+
+:index:`Starting Picard <starting>`
+===================================
+
+Once Picard has been installed on your system, most of the time you will be starting it by
+clicking an icon on your desktop or in a start menu.  This will run the program using the
+default location for the configuration file and configured logging level.  Picard can also
+be started from a command line prompt with some overrides available.  From the command line,
+you can also specify files or directories to load into Picard for processing.  Please see
+:doc:`/appendices/command_line` for more details about the available options.
+
+As of version 3, Picard will try to only run a single instance of the program at a time.
+When the program is started, it checks to see if there is another instance of that version, configuration file and plugin startup status ``-P``
+already running.  If the same version is already running, any files or directories specified
+on the command line of the new instance will be passed to the already running instance for
+processing and the new duplicate instance will be shut down.  This allows batch processing
+of files to be initiated automatically from other processes.  If there is no instance of that
+version already running, Picard will start normally.  Additionally, Picard can be started in
+"stand-alone" mode, in which case it neither sends information to an already running instance
+nor accepts information from another instance.
+
+Instances started with command-line argument ``-s / --stand-alone`` always start as stand-alone.
+
+If there is already an instance running when another instance is started that doesn't result in a
+stand-alone instance, any of the command-line overrides ``-d / --debug``, ``-M / --no-player``
+or ``-N / -no-restore`` of the new duplicate instance will be ignored, and only the specified
+files or directories (if any) will be passed to the running instance for processing.  Similarly,
+if a primary instance has been started with any of these overrides specified on the command line,
+starting a subsequent instance of that version without the override will not modify the user
+interface settings of the currently running instance.
+
+All instances started with the ``-h / --help``, ``-v / --version`` or ``-V / --long-version``
+command line arguments will always output the requested product information and exit, regardless of
+whether or not another instance is running.
+
+.. raw:: latex
+
+   \clearpage

--- a/index.rst
+++ b/index.rst
@@ -51,6 +51,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
    General Usage <usage/using>
    usage/other
    usage/option_profiles
+   usage/command_processing
    extending/extending
    faq/faq
 

--- a/index.rst
+++ b/index.rst
@@ -36,6 +36,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
    :hidden:
 
    getting_started/download
+   getting_started/starting
    getting_started/screen_main
    getting_started/status_icons
    config/configuration

--- a/pdf.rst
+++ b/pdf.rst
@@ -22,6 +22,7 @@ MusicBrainz Picard
    workflows/workflows
    usage/other
    usage/option_profiles
+   usage/command_processing
    extending/extending
    troubleshooting/pdf_troubleshooting
    faq/faq

--- a/usage/command_processing.rst
+++ b/usage/command_processing.rst
@@ -1,0 +1,90 @@
+.. MusicBrainz Picard Documentation Project
+
+:index:`Command and Batch Processing <command processing, batch processing, processing; batch>`
+===============================================================================================
+
+As of version 2.9, Picard will try to only run a single instance of the program at a time.
+When the program is started, it checks to see if there is another instance of that version,
+configuration file and plugin startup status ``-P`` already running.  If the same version
+is already running, any files or directories specified on the command line of the new
+instance, along with any executable commands specified with the ``-e`` or ``-exec`` options
+will be passed to the already running instance for processing and the new duplicate instance
+will be shut down.  This allows batch processing of files to be initiated automatically from
+other processes.  If there is no instance of that version already running, Picard will start
+normally.
+
+For example if there is an instance of Picard running and a second instance is started with
+the command line:
+
+.. code::
+
+   picard -e load mbid://release/dbd0ce67-cae6-33eb-8f5a-1143a30c2353
+
+the load command will be passed to the running instance to load the specified release, and
+the second instance will be closed.
+
+This allows the user to set up dynamic batch processing of commands to automate the tagging
+process, especially when used with the ``FROM_FILE`` command to load a standard processing
+command sequence such as:
+
+.. code::
+
+   CLUSTER
+   LOOKUP_CLUSTERED
+   SAVE_MATCHED
+   REMOVE_SAVED
+   REMOVE_EMPTY
+
+or:
+
+.. code::
+
+   LOOKUP_CD path/to/ripper.log
+   SAVE_MATCHED
+   FINGERPRINT
+   SUBMIT_FINGERPRINTS
+   REMOVE_SAVED
+   REMOVE_EMPTY
+
+or even something like:
+
+.. code::
+
+   # Load a directory of files to process
+   LOAD path/to/directory/of/unprocessed/files
+
+   # Try clustering and lookup the clusters first
+   CLUSTER
+   LOOKUP_CLUSTERED
+
+   # Save matched clusters
+   SAVE_MATCHED
+
+   # Calculate and submit fingerprints for the matched files
+   FINGERPRINT
+   SUBMIT_FINGERPRINTS
+
+   # Clean up and remove the saved files
+   REMOVE_SAVED
+   REMOVE_EMPTY
+
+   # Try scanning the remaining files to find matches
+   SCAN
+
+   # Save matched files from the scans
+   SAVE_MATCHED
+
+   # Clean up and remove the saved files
+   REMOVE_SAVED
+   REMOVE_EMPTY
+
+   # Any files remaining in the cluster pane could not be
+   # matched automatically
+
+Please see the :doc:`/usage/exec_commands` section for details regarding the commands
+available for execution.
+
+.. toctree::
+   :hidden:
+
+   /usage/exec_commands

--- a/usage/exec_commands.rst
+++ b/usage/exec_commands.rst
@@ -11,22 +11,32 @@ that Picard recognizes are:
 :index:`CLEAR_LOGS <executable commands; CLEAR_LOGS>`
 -----------------------------------------------------
 
+| Usage: **CLEAR_LOGS**
+| Implemented: Picard 2.9
+
 Clear the Picard logs.
 
 :index:`CLUSTER <executable commands; CLUSTER>`
 -----------------------------------------------
+
+| Usage: **CLUSTER**
+| Implemented: Picard 2.9
 
 Cluster all files in the cluster pane.
 
 :index:`FINGERPRINT <executable commands; FINGERPRINT>`
 -------------------------------------------------------
 
+| Usage: **FINGERPRINT**
+| Implemented: Picard 2.9
+
 Calculate acoustic fingerprints for all (matched) files in the album pane.
 
 :index:`FROM_FILE <executable commands; FROM_FILE>`
 ---------------------------------------------------
 
-Usage: FROM_FILE <file path>
+| Usage: **FROM_FILE <file path>**
+| Implemented: Picard 2.9
 
 Load commands from a file.  The file path can be either an absolute or relative
 path to a text file containing the commands to be executed. Each command to be
@@ -39,7 +49,8 @@ are ignored and will be logged as a warning.
 :index:`LOAD <executable commands; LOAD>`
 -----------------------------------------
 
-Usage: LOAD <supported MBID/URL or path to a file/directory>
+| Usage: **LOAD <supported MBID/URL or path to a file/directory>**
+| Implemented: Picard 2.9
 
 Load one or more files/directories/MBIDs/URLs to Picard. This is similar to including
 the file, directory path, URL or MBID on the command line.
@@ -54,21 +65,11 @@ MusicBrainz Identifier of the entity.
 If a specified item contains a space, it must be enclosed in quotes such as
 ``"/home/user/music/my song.mp3"``.
 
-
-Files and directories are specified including the path (either absolute or relative)
-to the file or directory, and may include drive specifiers. URLs are identified as
-beginning with either ``http://``
-or ``https://``. MBIDs are specified in the format ``mbid://<type>/<mbid>`` where
-``<type>`` is one of "release", "artist" or "track" and ``<mbid>`` is the MusicBrainz
-Identifier of the entity.
-
-If a specified item contains a space, it must be enclosed in quotes such as
-``"/home/user/music/my song.mp3"``.
-
 :index:`LOOKUP <executable commands; LOOKUP>`
 ---------------------------------------------
 
-Usage: LOOKUP [clustered|unclustered|all]
+| Usage: **LOOKUP [clustered|unclustered|all]**
+| Implemented: Picard 2.9
 
 Lookup files in the clustering pane. Options are clustered files, unclustered files or
 all files. If not specified, the command defaults to all files.
@@ -76,7 +77,8 @@ all files. If not specified, the command defaults to all files.
 :index:`LOOKUP_CD <executable commands; LOOKUP_CD>`
 ---------------------------------------------------
 
-Usage: LOOKUP_CD [device/log file]
+| Usage: **LOOKUP_CD [device/log file]**
+| Implemented: Picard 2.9
 
 Read CD from the selected drive or ripper log file, and looks it up on MusicBrainz. If
 no argument is specified, it defaults to the first (alphabetically) available disc drive.
@@ -84,70 +86,104 @@ no argument is specified, it defaults to the first (alphabetically) available di
 :index:`PAUSE <executable commands; PAUSE>`
 -------------------------------------------
 
-Usage: PAUSE <number of seconds to pause>
+| Usage: **PAUSE <number of seconds to pause>**
+| Implemented: Picard 2.9
 
 Pause executable command processing for the specified number of seconds.
 
 :index:`QUIT <executable commands; QUIT>`
 -----------------------------------------
 
-Exits the running instance of Picard.
+| Usage: **QUIT**
+| Implemented: Picard 2.9
+
+Exits the running instance of Picard. Once a ``QUIT`` command has been queued, Picard will
+not queue any further executable commands.
 
 :index:`REMOVE <executable commands; REMOVE>`
 ---------------------------------------------
 
-Usage: REMOVE <path to one or more files>
+| Usage: **REMOVE <path to one or more files>**
+| Implemented: Picard 2.9
 
 Removes the specified file(s) from Picard. Does nothing if no arguments provided.
 
 :index:`REMOVE_ALL <executable commands; REMOVE_ALL>`
 -----------------------------------------------------
 
+| Usage: **REMOVE_ALL**
+| Implemented: Picard 2.9
+
 Removes all files from Picard.
 
 :index:`REMOVE_EMPTY <executable commands; REMOVE_EMPTY>`
 ---------------------------------------------------------
+
+| Usage: **REMOVE_EMPTY**
+| Implemented: Picard 2.9
 
 Removes all empty clusters and albums.
 
 :index:`REMOVE_SAVED <executable commands; REMOVE_SAVED>`
 ---------------------------------------------------------
 
+| Usage: **REMOVE_SAVED**
+| Implemented: Picard 2.9
+
 Removes all saved files from the album pane.
 
 :index:`REMOVE_UNCLUSTERED <executable commands; REMOVE_UNCLUSTERED>`
 ---------------------------------------------------------------------
+
+| Usage: **REMOVE_UNCLUSTERED**
+| Implemented: Picard 2.9
 
 Removes all unclustered files from the cluster pane.
 
 :index:`SAVE_MATCHED <executable commands; SAVE_MATCHED>`
 ---------------------------------------------------------
 
+| Usage: **SAVE_MATCHED**
+| Implemented: Picard 2.9
+
 Saves all matched files from the album pane.
 
 :index:`SAVE_MODIFIED <executable commands; SAVE_MODIFIED>`
 -----------------------------------------------------------
+
+| Usage: **SAVE_MATCHED**
+| Implemented: Picard 2.9
 
 Saves all modified files from the album pane.
 
 :index:`SCAN <executable commands; SCAN>`
 -----------------------------------------
 
+| Usage: **SCAN**
+| Implemented: Picard 2.9
+
 Scans all files in the cluster pane.
 
 :index:`SHOW <executable commands; SHOW>`
 -----------------------------------------
+
+| Usage: **SHOW**
+| Implemented: Picard 2.9
 
 Make the running instance the currently active window.
 
 :index:`SUBMIT_FINGERPRINTS <executable commands; SUBMIT_FINGERPRINTS>`
 -----------------------------------------------------------------------
 
+| Usage: **SUBMIT_FINGERPRINTS**
+| Implemented: Picard 2.9
+
 Submits outstanding acoustic fingerprints for all (matched) files in the album pane.
 
 :index:`WRITE_LOGS <executable commands; WRITE_LOGS>`
 -----------------------------------------------------
 
-Usage: WRITE_LOGS <path to output file>
+| Usage: **WRITE_LOGS <path to output file>**
+| Implemented: Picard 2.9
 
 Writes the Picard logs to the specified output file.

--- a/usage/exec_commands.rst
+++ b/usage/exec_commands.rst
@@ -1,0 +1,153 @@
+.. MusicBrainz Picard Documentation Project
+
+:index:`Executable Commands <commands; executable, executable commands>`
+========================================================================
+
+Picard can accept commands for processing by specifying them on the command line using
+the ``-e`` option or loading them from a text file. Commands are case-insensitive, and
+are processed sequentially in the order that they are received. The executable commands
+that Picard recognizes are:
+
+:index:`CLEAR_LOGS <executable commands; CLEAR_LOGS>`
+-----------------------------------------------------
+
+Clear the Picard logs.
+
+:index:`CLUSTER <executable commands; CLUSTER>`
+-----------------------------------------------
+
+Cluster all files in the cluster pane.
+
+:index:`FINGERPRINT <executable commands; FINGERPRINT>`
+-------------------------------------------------------
+
+Calculate acoustic fingerprints for all (matched) files in the album pane.
+
+:index:`FROM_FILE <executable commands; FROM_FILE>`
+---------------------------------------------------
+
+Usage: FROM_FILE <file path>
+
+Load commands from a file.  The file path can be either an absolute or relative
+path to a text file containing the commands to be executed. Each command to be
+processed must be on a separate line along with its arguments (if applicable). Blank
+lines and lines beginning with an octothorpe (#) are ignored. Command files can
+include other command files by specifying them with another ``FROM_FILE`` command.
+Circular references (by including a command file that is currently being processed)
+are ignored and will be logged as a warning.
+
+:index:`LOAD <executable commands; LOAD>`
+-----------------------------------------
+
+Usage: LOAD <supported MBID/URL or path to a file/directory>
+
+Load one or more files/directories/MBIDs/URLs to Picard. This is similar to including
+the file, directory path, URL or MBID on the command line.
+
+Files and directories are specified including the path (either absolute or relative)
+to the file or directory, and may include drive specifiers. They can also be specified
+using the ``file://`` prefix. URLs are specified by using either the ``http://`` or
+``https://`` prefix. MBIDs are specified in the format ``mbid://<entity_type>/<mbid>``
+where ``<entity_type>`` is one of "release", "artist" or "track" and ``<mbid>`` is the
+MusicBrainz Identifier of the entity.
+
+If a specified item contains a space, it must be enclosed in quotes such as
+``"/home/user/music/my song.mp3"``.
+
+
+Files and directories are specified including the path (either absolute or relative)
+to the file or directory, and may include drive specifiers. URLs are identified as
+beginning with either ``http://``
+or ``https://``. MBIDs are specified in the format ``mbid://<type>/<mbid>`` where
+``<type>`` is one of "release", "artist" or "track" and ``<mbid>`` is the MusicBrainz
+Identifier of the entity.
+
+If a specified item contains a space, it must be enclosed in quotes such as
+``"/home/user/music/my song.mp3"``.
+
+:index:`LOOKUP <executable commands; LOOKUP>`
+---------------------------------------------
+
+Usage: LOOKUP [clustered|unclustered|all]
+
+Lookup files in the clustering pane. Options are clustered files, unclustered files or
+all files. If not specified, the command defaults to all files.
+
+:index:`LOOKUP_CD <executable commands; LOOKUP_CD>`
+---------------------------------------------------
+
+Usage: LOOKUP_CD [device/log file]
+
+Read CD from the selected drive or ripper log file, and looks it up on MusicBrainz. If
+no argument is specified, it defaults to the first (alphabetically) available disc drive.
+
+:index:`PAUSE <executable commands; PAUSE>`
+-------------------------------------------
+
+Usage: PAUSE <number of seconds to pause>
+
+Pause executable command processing for the specified number of seconds.
+
+:index:`QUIT <executable commands; QUIT>`
+-----------------------------------------
+
+Exits the running instance of Picard.
+
+:index:`REMOVE <executable commands; REMOVE>`
+---------------------------------------------
+
+Usage: REMOVE <path to one or more files>
+
+Removes the specified file(s) from Picard. Does nothing if no arguments provided.
+
+:index:`REMOVE_ALL <executable commands; REMOVE_ALL>`
+-----------------------------------------------------
+
+Removes all files from Picard.
+
+:index:`REMOVE_EMPTY <executable commands; REMOVE_EMPTY>`
+---------------------------------------------------------
+
+Removes all empty clusters and albums.
+
+:index:`REMOVE_SAVED <executable commands; REMOVE_SAVED>`
+---------------------------------------------------------
+
+Removes all saved files from the album pane.
+
+:index:`REMOVE_UNCLUSTERED <executable commands; REMOVE_UNCLUSTERED>`
+---------------------------------------------------------------------
+
+Removes all unclustered files from the cluster pane.
+
+:index:`SAVE_MATCHED <executable commands; SAVE_MATCHED>`
+---------------------------------------------------------
+
+Saves all matched files from the album pane.
+
+:index:`SAVE_MODIFIED <executable commands; SAVE_MODIFIED>`
+-----------------------------------------------------------
+
+Saves all modified files from the album pane.
+
+:index:`SCAN <executable commands; SCAN>`
+-----------------------------------------
+
+Scans all files in the cluster pane.
+
+:index:`SHOW <executable commands; SHOW>`
+-----------------------------------------
+
+Make the running instance the currently active window.
+
+:index:`SUBMIT_FINGERPRINTS <executable commands; SUBMIT_FINGERPRINTS>`
+-----------------------------------------------------------------------
+
+Submits outstanding acoustic fingerprints for all (matched) files in the album pane.
+
+:index:`WRITE_LOGS <executable commands; WRITE_LOGS>`
+-----------------------------------------------------
+
+Usage: WRITE_LOGS <path to output file>
+
+Writes the Picard logs to the specified output file.


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

New features were introduced in https://github.com/metabrainz/picard/pull/2116 and https://github.com/metabrainz/picard/pull/2173

### Description of the Change

Add information about the use of the single instance and passing files and command information to the running instance for processing.  Add discussion of available executable commands and batch command processing from a command text file.

This PR builds upon the changes made by @skelly37 in https://github.com/metabrainz/picard-docs/pull/174 which has been superceded and the changes merged into this PR.

### Additional Action Required

Once merged, the translation files will need to be updated.
