### PR TITLE
Add FAQ entry about using rclone on Windows to mount cloud storage

### DIFF
--- a/faq/faq_usage.rst
+++ b/faq/faq_usage.rst
@@ -78,3 +78,21 @@ removable media by running the following command on a terminal:
 .. code-block:: bash
 
    snap connect picard:removable-media
+
+
+On Windows, how do I solve errors on saving to cloud storage drives mounted with rclone?
+----------------------------------------------------------------------------------------
+
+rclone can provide access to cloud storage by mounting a virtual filesystem as a drive.  This
+virtual filesystem has some differences to a real filesystem which can cause compatibility issues.
+
+For full compatibility with Picard you need to mount the cloud storage with rclone as a network
+drive with the `--network-mode` parameter and set the cache mode to `--vfs-cache-mode=writes`
+or `--vfs-cache-mode=full`.  Your rclone command to mount a remote as drive X:
+might look like this:
+
+.. code-block:: batch
+
+   rclone mount --vfs-cache-mode=writes --network-mode remote:path/to/files X:
+
+Please refer to the rclone documentation for more details.


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

In PICARD-2600 the user was trying to use Picard together with rclone on Windows to access and directly tag files stored in Google cloud storage. rclone is providing a virtual file system, but in order to be completely compatible with all file operations done by Picard (mostly seeking in files to find the tags and using `os.path.realpath`) some options need to be set correctly when using the `rclone mount command`.

### Description of the Change

Add a FAQ entry specific to using rclone on Windows with the proper options.