### PR TITLE
Add note to `$copy()` about source not enclosed by percent signs.

### DIFF
--- a/functions/func_copy.rst
+++ b/functions/func_copy.rst
@@ -14,8 +14,13 @@ $copy
 Copies metadata from variable ``source`` to ``target``. The difference from ``$set(target,%source%)`` is
 that ``$copy(target,source)`` copies multi-value variables without flattening them.
 
-Note that if the variable ``target`` already exists, it will be overwritten by ``source``.
+.. note::
 
+   Unlike most functions, in this case the ``source`` is specified **without** enclosing it with percent signs (%).
+
+.. warning::
+
+   If the variable ``target`` already exists, it will be overwritten by ``source``.
 
 **Example:**
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [x] Other

### Reason for the Change

There is often confusion regarding the `$copy()` command because, unlike most commands, the `source` argument is specified without being enclosed by percent signs.

### Description of the Change

Add a note to specifically point out this difference.

### Additional Action Required

One approved, the translation files will need to be updated.
