### PR TITLE
Standardize notes between related functions

### DIFF
--- a/functions/func_copymerge.rst
+++ b/functions/func_copymerge.rst
@@ -17,8 +17,9 @@ without flattening them.  Following the operation, ``target`` will be a multi-va
 
 If ``keep_duplicates`` is set, then the duplicates will not be removed from the result.
 
-Note that the variable names for ``target`` and ``source`` are passed directly without enclosing them
-in percent signs '%'.
+.. note::
+
+   Unlike most functions, in this case the ``source`` is specified **without** enclosing it with percent signs (%).
 
 
 **Example:**

--- a/functions/func_dateformat.rst
+++ b/functions/func_dateformat.rst
@@ -13,15 +13,18 @@ $dateformat
 
 Returns the input ``date`` in the specified ``format``, which is based on the
 standard Python ``strftime`` `format codes <https://strftime.org>`_. If no ``format`` is specified
-the date will be returned in the form '2020-02-15'.  Note that any special
-characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the
-examples below.
+the date will be returned in the form '2020-02-15'.
 
 The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated
 by any non-numeric characters.  The default order for the input date is "ymd".  This can be changed
 by specifying a ``date_order`` of either "dmy" or "mdy".
 
 If either the ``date`` or ``format`` are invalid an empty string will be returned.
+
+.. note::
+
+   Any special characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the
+   examples below.
 
 .. warning::
 

--- a/functions/func_datetime.rst
+++ b/functions/func_datetime.rst
@@ -13,9 +13,12 @@ $datetime
 
 Returns the current date and time in the specified format, which is based on the
 standard Python ``strftime`` `format codes <https://strftime.org>`_. If no format is specified
-the date and time will be returned in the form '2020-02-15 14:26:32'.  Note that any special
-characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the
-examples below.
+the date and time will be returned in the form '2020-02-15 14:26:32'.
+
+.. note::
+
+   Any special characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the
+   examples below.
 
 .. warning::
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Similar notes on scripting functions were displayed or worded differently.  The different wording causes more translation strings.

### Description of the Change

Standardize wording and presentation of similar notes on related functions.

### Additional Action Required

Update translation files.
