### PR TITLE
Add variables `_file_created_timestamp` and `_file_modified_timestamp`

### DIFF
--- a/variables/variables_file.rst
+++ b/variables/variables_file.rst
@@ -38,6 +38,14 @@ These variables are populated from MusicBrainz data for most releases, without a
 
     The name of the file without extension. (*since Picard 1.1*)
 
+**_file_created_timestamp**
+
+    The file creation timestamp in the form 'YYYY-MM-DD HH:MM:SS' as reported by the file system. (*since Picard 2.9*)
+
+**_file_modified_timestamp**
+
+    The file modification timestamp in the form 'YYYY-MM-DD HH:MM:SS' as reported by the file system. (*since Picard 2.9*)
+
 **_format**
 
     Media format of the file (e.g.: MPEG-1 Audio).


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Two new file variables (`_file_created_timestamp` and `_file_modified_timestamp`) were added in https://github.com/metabrainz/picard/pull/2194

### Description of the Change

Add descriptions for the new file variables.

### Additional Action Required

Translation files will need to be updated.
