### PR TITLE
PICARD-2581: Add note about standard keyboard shortcuts

### DIFF
--- a/appendices/keyboard_shortcuts.rst
+++ b/appendices/keyboard_shortcuts.rst
@@ -13,6 +13,8 @@
 Appendix D: :index:`Keyboard Shortcuts <user interface; keyboard shortcuts>`
 ============================================================================
 
+In addition to the standard keyboard shortcuts provided by your operating system for things like text selection, copy and paste, Picard also provides the following:
+
 Main window
 -----------
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

As discussed in PICARD-2581 it should be clarified that the keyboard shortcuts documented are in addition to the standard keyboard shortcuts provided by the user's operating system.

### Description of the Change

Add a brief note that the shortcuts are in addition to the standard operating system shortcuts.

### Additional Action Required

Update translation files.
