### PR TITLE
Add `PLUGIN_USER_GUIDE_URL` variable to plugins api documentation

### DIFF
--- a/appendices/plugins_api.rst
+++ b/appendices/plugins_api.rst
@@ -24,6 +24,7 @@ Each plugin must provide some metadata as variables. Those variables should be p
    PLUGIN_API_VERSIONS = ['2.7', '2.8']
    PLUGIN_LICENSE = "GPL-2.0-or-later"
    PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+   PLUGIN_USER_GUIDE_URL = "https://my.program.site.org/example_plugin_documentation.html"
 
 Variables explanation:
 
@@ -47,6 +48,10 @@ Variables explanation:
   one you chose is not available in the list.
 
 * **PLUGIN_LICENSE_URL** should be set to a URL pointing to the full license text.
+
+* **PLUGIN_USER_GUIDE_URL** should be set to a URL pointing to the documentation for the plugin.  This variable is
+  optional and may be omitted.  If a URL is provided, it will be shown as a clickable link in the description
+  displayed for the plugin in the Plugins option settings screen.
 
 
 :index:`Metadata Processors <plugins; metadata processors>`


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

In https://github.com/metabrainz/picard/pull/2199 the `PLUGIN_USER_GUIDE_URL` variable was added to the plugin api.

### Description of the Change

Update the plugin api documentation to include the new variable.

### Additional Action Required

Once merged, the translation POT files will need to be updated.
