### PR TITLE
Update texts to reflect switch to ID3v2.4 by default

### DIFF
--- a/config/options_tags_compatibility_id3.rst
+++ b/config/options_tags_compatibility_id3.rst
@@ -8,9 +8,9 @@
 
 **ID3v2 version**
 
-   Although ID3v2.4 is the latest version, its support in music players is still lacking. While some software has
-   no problem using version 2.4 tags, others may not be able to read the tags and display the information. Support
-   for ID3v2.4 in other media players (such as smartphones) is variable.
+   ID3v2.4 is the latest version and the default since Picard 2.9. Most modern software
+   and devices can read ID3v2.4 tags.  If you encounter issues with tag reading with your
+   music player try using v2.3 instead.
 
    Other than native support for multi-valued tags in v2.4, the :doc:`Picard Tag Mapping </appendices/tag_mapping>`
    section will show you what you lose when choosing v2.3 instead of v2.4.

--- a/faq/faq_config.rst
+++ b/faq/faq_config.rst
@@ -34,7 +34,7 @@ My tags are :index:`truncated <tags; truncated, WMP; tags>` to 30 characters in 
 ---------------------------------------------------------------------------------------------------------
 
 Picard's default settings write ID3v2.4 and ID3v1 tags to files.  Older WMP versions can't read ID3v2.4, so it falls
-back to ID3v1 which has a limitation of 30 characters per title.  To solve this on versions prior to 0.14, configure
+back to ID3v1 which has a limitation of 30 characters per title.  To resolve this issue, configure
 Picard to write ID3v2.3 tags instead.
 
 Since Windows 10 Creators Update (version 1703) ID3v2.4 is supported and the above issue should no longer apply.

--- a/faq/faq_config.rst
+++ b/faq/faq_config.rst
@@ -33,7 +33,7 @@ embedded cover art. As a work-around, you can configure Picard to write ID3v2.3 
 My tags are :index:`truncated <tags; truncated, WMP; tags>` to 30 characters in Windows Media Player!
 ---------------------------------------------------------------------------------------------------------
 
-Picard's default settings is write ID3v2.4 and ID3v1 tags to files.  Older WMP versions can't read ID3v2.4, so it falls
+Picard's default settings write ID3v2.4 and ID3v1 tags to files.  Older WMP versions can't read ID3v2.4, so it falls
 back to ID3v1 which has a limitation of 30 characters per title.  To solve this on versions prior to 0.14, configure
 Picard to write ID3v2.3 tags instead.
 

--- a/faq/faq_config.rst
+++ b/faq/faq_config.rst
@@ -33,11 +33,11 @@ embedded cover art. As a work-around, you can configure Picard to write ID3v2.3 
 My tags are :index:`truncated <tags; truncated, WMP; tags>` to 30 characters in Windows Media Player!
 ---------------------------------------------------------------------------------------------------------
 
-Prior to version 0.14, Picard's default settings were to write ID3v2.4 and ID3v1 tags to files. WMP can't read ID3v2.4, so it falls
-back to ID3v1 which has a limitation of 30 characters per title. To solve this on versions prior to 0.14, configure Picard to write
-ID3v2.3 tags instead.
+Picard's default settings is write ID3v2.4 and ID3v1 tags to files.  Older WMP versions can't read ID3v2.4, so it falls
+back to ID3v1 which has a limitation of 30 characters per title.  To solve this on versions prior to 0.14, configure
+Picard to write ID3v2.3 tags instead.
 
-Starting with version 0.14, the default settings have been changed to ID3v2.3 and this should no longer be an issue.
+Since Windows 10 Creators Update (version 1703) ID3v2.4 is supported and the above issue should no longer apply.
 
 
 How do I tell Picard which :index:`browser <pair: configuration; browser>` to use?

--- a/variables/tags_basic.rst
+++ b/variables/tags_basic.rst
@@ -217,7 +217,7 @@ Most tags beginning with ``musicbrainz_`` provide the :index:`MusicBrainz Identi
 
    .. note::
 
-      If you are storing tags in MP3 files as ID3v2.3 (which is the Windows and iTunes compatible version) then the original date can only be stored as a year.
+      If you are storing tags in MP3 files as ID3v2.3 then the original date can only be stored as a year.
 
 **originalyear**
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Picard 2.9 will change to ID3v2.4 by default, see https://github.com/metabrainz/picard/pull/2209 and PICARD-900

### Description of the Change

Update texts discussing ID3 versions to reflect the new default.