### PR TITLE
Embed video tutorials into corresponding doc pages

### DIFF
--- a/about_picard/introduction.rst
+++ b/about_picard/introduction.rst
@@ -89,3 +89,11 @@ Sometimes Picard needs to rewrite the entire music file in order to add or updat
 few seconds, and the delay becomes even longer if the file is accessed across a network (e.g.: file is
 read from or written to a NAS device).  The recommended "best practice" is to process all files on a local drive
 and then move them to the desired remote directory once processing is complete.
+
+.. only:: html
+
+   Introduction video
+   ------------------
+
+   .. youtube:: zMAc-UyO0NA
+      :privacy_mode:

--- a/conf.py
+++ b/conf.py
@@ -71,6 +71,7 @@ extensions = [
     "recommonmark",
     "notfound.extension",
     "taggerscript",
+    "sphinxcontrib.youtube",
     # "sphinx_rtd_theme",
     # "picard_theme",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ sphinx-rtd-theme>=0.5.1
 docutils>=0.16,<0.17
 sphinx-notfound-page>=0.5
 sphinx-intl==2.0.1
+sphinxcontrib-youtube==1.2.0
 XlsxWriter>=1.3.7
 jinja2==3.1.2
 flake8

--- a/usage/attach_disc_id.rst
+++ b/usage/attach_disc_id.rst
@@ -70,6 +70,14 @@ The steps to follow to submit a disc id are:
    .. image:: images/cd_lookup_4.png
       :width: 100%
 
+.. only:: html
+
+   Video tutorial
+   --------------
+
+   .. youtube:: C44k7VKY9J8
+      :privacy_mode:
+
 .. raw:: latex
 
    \clearpage

--- a/usage/submit_acoustid.rst
+++ b/usage/submit_acoustid.rst
@@ -109,6 +109,14 @@ Submitting when not using Scan to identify the release
    .. image:: images/submit_acoustid_8.png
       :width: 100%
 
+.. only:: html
+
+   Video tutorial
+   --------------
+
+   .. youtube:: XX8aio5hDPI
+      :privacy_mode:
+
 .. raw:: latex
 
    \clearpage


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Description of the Change

This change embeds tutorial videos from the MetaBrainz Youtube channel that aerozol recently made. This can help users who prefer the visual guidance through the program over the textual description.

The following videos are embedded on the relevant pages:

- What is MusicBrainz Picard
- How to add a DiscID to MusicBrainz
- What are AcoustIDs and how to submit them

The videos are embedded using the [`sphinxcontrib.youtube`](https://github.com/sphinx-contrib/youtube) module.

### Additional Action Required

I set the `:privacy_mode:` flag for embedding the videos. This is supposed to load the videos via youtube-nocookie.com to avoid the Google cookies. However, in my tests this did currently not work as intended, see https://github.com/sphinx-contrib/youtube/issues/57