### PR TITLE
Create new top level section for video tutorials

### DIFF
--- a/about_picard/introduction.rst
+++ b/about_picard/introduction.rst
@@ -28,6 +28,12 @@ alternate formats, including a PDF version suitable for printing. Links to addit
 information such as scripts, plugins and tutorials are provided when available rather than trying
 to reproduce the information in this document.
 
+.. only:: html
+
+   .. note::
+
+      There is also an :doc:`Introduction to Picard Video Tutorial </tutorials/v_introduction>` available.
+
 In order to effectively use Picard, it is important to understand what the program can do and,
 equally important, what it cannot do.  Picard is primarily intended to tag and organize albums containing tracks,
 guided by the user to the specific release of the album that they have, and then to keep the metadata for these
@@ -89,11 +95,3 @@ Sometimes Picard needs to rewrite the entire music file in order to add or updat
 few seconds, and the delay becomes even longer if the file is accessed across a network (e.g.: file is
 read from or written to a NAS device).  The recommended "best practice" is to process all files on a local drive
 and then move them to the desired remote directory once processing is complete.
-
-.. only:: html
-
-   Introduction video
-   ------------------
-
-   .. youtube:: zMAc-UyO0NA
-      :privacy_mode:

--- a/index.rst
+++ b/index.rst
@@ -95,6 +95,17 @@ plugins and tutorials are provided when available rather than trying to reproduc
 
 
 .. toctree::
+   :caption: Video Tutorials
+   :hidden:
+   :maxdepth: 0
+   :titlesonly:
+
+   tutorials/v_introduction
+   tutorials/v_attach_disc_id
+   tutorials/v_submit_acoustid
+
+
+.. toctree::
    :caption: Appendices
    :hidden:
    :maxdepth: 0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 """\
 Python script used to provide development support functions.
 """
-# Copyright (C) 2020-2021 Bob Swift
+# Copyright (C) 2020-2023 Bob Swift
 # Copyright (C) 2021 Philipp Wolfer
 
 # pylint: disable=too-many-lines
@@ -25,8 +25,8 @@ import conf
 import tag_mapping
 
 SCRIPT_NAME = 'Picard Docs Builder'
-SCRIPT_VERS = '0.16'
-SCRIPT_COPYRIGHT = '2021'
+SCRIPT_VERS = '0.17'
+SCRIPT_COPYRIGHT = '2021-2023'
 SCRIPT_AUTHOR = 'Bob Swift'
 
 PACKAGE_NAME = 'picard-docs'
@@ -153,7 +153,10 @@ IGNORE_DIRECTIVES = [
     'productionlist',
 
     # Command line parameter docs
-    'option', 'describe'
+    'option', 'describe',
+
+    # Specialty directives
+    'youtube',
 ]
 
 IGNORE_ROLES = [

--- a/tutorials/v_attach_disc_id.rst
+++ b/tutorials/v_attach_disc_id.rst
@@ -1,0 +1,7 @@
+.. MusicBrainz Picard Documentation Project
+
+Attaching a Disc ID
+===================
+
+.. youtube:: C44k7VKY9J8
+   :privacy_mode:

--- a/tutorials/v_introduction.rst
+++ b/tutorials/v_introduction.rst
@@ -1,0 +1,7 @@
+.. MusicBrainz Picard Documentation Project
+
+Introduction to Picard
+======================
+
+.. youtube:: zMAc-UyO0NA
+   :privacy_mode:

--- a/tutorials/v_submit_acoustid.rst
+++ b/tutorials/v_submit_acoustid.rst
@@ -1,0 +1,7 @@
+.. MusicBrainz Picard Documentation Project
+
+Submitting an AcoustID
+======================
+
+.. youtube:: XX8aio5hDPI
+   :privacy_mode:

--- a/usage/attach_disc_id.rst
+++ b/usage/attach_disc_id.rst
@@ -7,9 +7,15 @@ Disc IDs are very useful for identifying CDs and allowing MusicBrainz to know th
 on a CD. Thus, it is very valuable to add them when submitting a new CD release or when you have a
 CD release that does not have a Disc ID attached.
 
-.. note::
+.. warning::
 
    Please do not add DiscIDs from CDs that are burned at home.
+
+.. only:: html
+
+   .. note::
+
+      There is also a :doc:`Video Tutorial </tutorials/v_attach_disc_id>` available which demonstrates how to attach a disc id to a release in MusicBrainz.
 
 The steps to follow to submit a disc id are:
 
@@ -69,14 +75,6 @@ The steps to follow to submit a disc id are:
 
    .. image:: images/cd_lookup_4.png
       :width: 100%
-
-.. only:: html
-
-   Video tutorial
-   --------------
-
-   .. youtube:: C44k7VKY9J8
-      :privacy_mode:
 
 .. raw:: latex
 

--- a/usage/submit_acoustid.rst
+++ b/usage/submit_acoustid.rst
@@ -16,6 +16,12 @@ tutorial for additional information.
    AcoustID was calculated and whether it ready for submission (red = unsubmitted, grey = already
    submitted).
 
+.. only:: html
+
+   .. note::
+
+      There is also a :doc:`Video Tutorial </tutorials/v_submit_acoustid>` available which demonstrates how to submit AcoustIDs.
+
 There are two methods for submitting acoustic fingerprints, depending on the workflow that you are
 using to identify the releases that you are tagging. Note that both methods require that you first
 match your audio files to release and track information from the MusicBrainz database. See the
@@ -108,14 +114,6 @@ Submitting when not using Scan to identify the release
 
    .. image:: images/submit_acoustid_8.png
       :width: 100%
-
-.. only:: html
-
-   Video tutorial
-   --------------
-
-   .. youtube:: XX8aio5hDPI
-      :privacy_mode:
 
 .. raw:: latex
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [x] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Further to the discussion in https://github.com/metabrainz/picard-docs/pull/196

### Description of the Change

Create a new top-level section on the website only to more promenently display the available video tutorials.

### Additional Action Required

Once merged, the translation templates will need to be updated.
