### PR TITLE
Exclude video tutorial pages from epub file

### DIFF
--- a/about_picard/introduction.rst
+++ b/about_picard/introduction.rst
@@ -28,7 +28,7 @@ alternate formats, including a PDF version suitable for printing. Links to addit
 information such as scripts, plugins and tutorials are provided when available rather than trying
 to reproduce the information in this document.
 
-.. only:: html
+.. only:: html and not epub
 
    .. note::
 

--- a/conf.py
+++ b/conf.py
@@ -8,9 +8,11 @@
 
 
 import datetime
+import glob
 import os
 import re
 import sys
+
 
 # -- Path setup --------------------------------------------------------------
 
@@ -210,13 +212,22 @@ epub_post_files = [
     ('genindex.xhtml', 'INDEX'),
 ]
 
-epub_exclude_files = [
-    '404.xhtml',
-    'index.xhtml',
-    'not_found.xhtml',
-    'pdf.xhtml',
-    os.path.join('examples', 'examples.xhtml'),
-]
+def _exclude_files_helper():
+    excludes = [
+        '404.xhtml',
+        'index.xhtml',
+        'not_found.xhtml',
+        'pdf.xhtml',
+        'examples/examples.xhtml',
+    ]
+
+    for filepath in glob.glob('tutorials/v_*'):
+        if filepath.endswith('.rst'):
+            excludes.append(filepath[:-3] + 'xhtml')
+
+    return excludes
+
+epub_exclude_files = _exclude_files_helper()
 
 # -- Options for custom 404 page --------------------------------------
 

--- a/usage/attach_disc_id.rst
+++ b/usage/attach_disc_id.rst
@@ -11,7 +11,7 @@ CD release that does not have a Disc ID attached.
 
    Please do not add DiscIDs from CDs that are burned at home.
 
-.. only:: html
+.. only:: html and not epub
 
    .. note::
 

--- a/usage/submit_acoustid.rst
+++ b/usage/submit_acoustid.rst
@@ -16,7 +16,7 @@ tutorial for additional information.
    AcoustID was calculated and whether it ready for submission (red = unsubmitted, grey = already
    submitted).
 
-.. only:: html
+.. only:: html and not epub
 
    .. note::
 


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The epub file build includes the video tutorial pages as extra pages (not in the table of contents), placing them at the end of the document after the Index section.

### Description of the Change

Add the video tutorial pages to the list of excluded files when building the epub file.  Use a helper function to automatically identify the files to exclude.

### Additional Action Required

None.
