### PR TITLE
Add note about multi-value parsing within loop functions code

### DIFF
--- a/functions/func_foreach.rst
+++ b/functions/func_foreach.rst
@@ -20,6 +20,10 @@ A literal value representing a multi-value can be substituted for ``name``, usin
 (or a semicolon followed by a space "; " if not passed) to coerce the value into a proper multi-valued
 variable.
 
+.. note::
+
+   Due to the way that the function parses the ``code`` parameter, multi-value functions that accept the name of the multi-value variable directly (without it being enclosed in percent signs) will not work as expected. To use these functions, the multi-value variable must be expanded by enclosing it with percent signs and re-split by adding "; " (semicolon and single space) as the separator parameter. For example, where you would normally use ``$getmulti(variable,0)`` you have to replace it with ``$getmulti(%variable%,0,; )``.
+
 
 **Example:**
 

--- a/functions/func_while.rst
+++ b/functions/func_while.rst
@@ -20,6 +20,10 @@ within the ``code`` script.
     The function limits the maximum number of iterations to 1000 as a safeguard against
     accidentally creating an infinite loop.
 
+.. note::
+
+   Due to the way that the function parses the ``code`` parameter, multi-value functions that accept the name of the multi-value variable directly (without it being enclosed in percent signs) will not work as expected. To use these functions, the multi-value variable must be expanded by enclosing it with percent signs and re-split by adding "; " (semicolon and single space) as the separator parameter. For example, where you would normally use ``$getmulti(variable,0)`` you have to replace it with ``$getmulti(%variable%,0,; )``.
+
 
 **Example:**
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

As discussed in the [Community Forum](https://community.metabrainz.org/t/help-with-script-and-foreach-loop/647974) there is a problem accessing multi-value functions within a loop function.

### Description of the Change

This adds a note to the documentation for the `$foreach()` and `$while()` loop functions warning of the issue and providing an example of a work-around.

### Additional Action Required

Once merged, the translation files will need to be updated.
