### PR TITLE
Update the definition of the `director` tag to include Audio Director

### DIFF
--- a/variables/tags_advanced.rst
+++ b/variables/tags_advanced.rst
@@ -44,6 +44,10 @@ If you enable tagging with "Use track relationships", you get these extra tags:
     Tha names of the conductors associated with the track.  These can include the conductor and chorus master, and could
     be associated with the release or recording.
 
+**director**
+
+   The director of a track as provided by the Video Director or Audio Director relationship in MusicBrainz.  (*Since Picard 2.6, updated in Picard 2.9*)
+
 **djmixer**
 
     The names of the DJ mixers for the track. (*since Picard 0.9*)

--- a/variables/tags_basic.rst
+++ b/variables/tags_basic.rst
@@ -106,10 +106,6 @@ Most tags beginning with ``musicbrainz_`` provide the :index:`MusicBrainz Identi
 
     Release Date (YYYY-MM-DD) - the date that the release (album) was issued.
 
-**director**
-
-   The director of a track as provided by the Video Director or Audio Director relationship in MusicBrainz.  (*Since Picard 2.6, updated in Picard 2.9*)
-
 **discnumber**
 
     Number of the disc in this release that contains this track.

--- a/variables/tags_basic.rst
+++ b/variables/tags_basic.rst
@@ -108,7 +108,7 @@ Most tags beginning with ``musicbrainz_`` provide the :index:`MusicBrainz Identi
 
 **director**
 
-   The director of a video track as provided by the Video Director relationship in MusicBrainz.  (*Since Picard 2.6*)
+   The director of a track as provided by the Video Director or Audio Director relationship in MusicBrainz.  (*Since Picard 2.6, updated in Picard 2.9*)
 
 **discnumber**
 


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The `director` tag definition is being changed in https://github.com/metabrainz/picard/pull/2276

### Description of the Change

Update the tag definition in the documentation to match the change in Picard.

### Additional Action Required

Do not merge until the change is merged into Picard.  Once merged, the translation files will need to be updated.
