### PR TITLE
General improvements and python script cleanup

### DIFF
--- a/_extensions/taggerscript.py
+++ b/_extensions/taggerscript.py
@@ -3,7 +3,13 @@
 """
 
 from pygments.lexer import RegexLexer
-from pygments.token import Comment, Keyword, Name, String, Text
+from pygments.token import (
+    Comment,
+    Keyword,
+    Name,
+    String,
+    Text,
+)
 from sphinx.application import Sphinx
 
 

--- a/conf.py
+++ b/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('_extensions'))
 # import picard_theme
 
 this_year = datetime.datetime.now().year
-copyright_year = str(this_year) if this_year == 2020 else '2020-{0}'.format(this_year)
+copyright_year = str(this_year) if this_year == 2020 else f'2020-{this_year}'
 
 # -- Project information -----------------------------------------------------
 
@@ -151,7 +151,7 @@ html_copy_source = False
 release = version   # For display on cover of PDF document
 
 latex_documents = [
-    ('pdf', '{0}.tex'.format(base_filename), project, '', 'manual', False),
+    ('pdf', f'{base_filename}.tex', project, '', 'manual', False),
     # ('pdf', '{0}.tex'.format(base_filename), project, 'Edited by Bob Swift', 'manual', False),
     # ('pdf', '{0}.tex'.format(base_filename), project, '', 'howto', False),
 ]
@@ -189,7 +189,7 @@ epub_basename = base_filename
 epub_theme = 'epub'
 
 # Metadata included in the epub file.
-epub_title = '{0} User Guide ({1})'.format(project, major_minor,)
+epub_title = f'{project} User Guide ({major_minor})'
 epub_description = 'A User Guide for MusicBrainz Picard.'
 epub_author = 'Bob Swift (Editor)'
 epub_contributor = 'Members of the MusicBrainz Community'
@@ -200,7 +200,7 @@ epub_tocdepth = 3
 epub_tocscope = 'includehidden'
 
 epub_cover = ('_static/picard_logo_256.png', 'epub-cover.html')
-epub_guide = (('cover', 'epub-cover.xhtml', u'Cover Page'),)
+epub_guide = (('cover', 'epub-cover.xhtml', 'Cover Page'),)
 
 # epub_show_urls = 'inline'
 # epub_show_urls = 'footnote'
@@ -211,6 +211,7 @@ epub_use_index = True
 epub_post_files = [
     ('genindex.xhtml', 'INDEX'),
 ]
+
 
 def _exclude_files_helper():
     excludes = [
@@ -226,6 +227,7 @@ def _exclude_files_helper():
             excludes.append(filepath[:-3] + 'xhtml')
 
     return excludes
+
 
 epub_exclude_files = _exclude_files_helper()
 

--- a/pylintrc
+++ b/pylintrc
@@ -324,8 +324,8 @@ max-module-lines=1000
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
+# no-space-check=trailing-comma,
+#                dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -560,4 +560,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/stage_translation_files.py
+++ b/stage_translation_files.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 
 
+SHOW_COMPARISONS = 1    # 0 = none, 1 = differences only, 2 = all comparisons
+
 COMMAND_TIMEOUT = 300
 LOCALE_DIR = '_locale'
 
@@ -28,15 +30,13 @@ def get_stdout_from_command(command: str):
     return response.stdout
 
 
-def parse_git_status(git_stat: list, files_to_add: dict, files_to_ignore: set, rst_files: set, pot_files: set):
-    """Parse the git status response.
+def parse_git_status(git_stat: list, files_to_stage: dict, files_to_ignore: set):
+    """Parse the git status response to add new or deleted files.
 
     Args:
         git_stat (list): List of lines in the git status response
-        files_to_add (dict): Dictionary of files to add to git staging
-        files_to_ignore (set): Set of files not to add to the git staging
-        rst_files (set): Set of *.rst files found
-        pot_files (set): Set of *.pot files found
+        files_to_stage (dict): Dictionary of files to add to git staging
+        files_to_ignore (set): Set of files to not add to git staging
     """
     for line in git_stat:
         matches = re.match(r"\s*(\S+)\s+(.*)$", line)
@@ -44,101 +44,143 @@ def parse_git_status(git_stat: list, files_to_add: dict, files_to_ignore: set, r
             continue
         status = matches.group(1)
         fullfilename = matches.group(2)
-        filename = fullfilename.split('/')[-1]
-        root, ext = os.path.splitext(filename)
-        if status == "D":
-            files_to_add[fullfilename] = 'Deleted'
-            if ext == '.rst':
-                files_to_ignore.add(root + '.pot')
-                files_to_ignore.add(root + '.po')
-            if ext == '.pot':
-                files_to_ignore.add(root + '.po')
-            continue
-        if status == "??" and "/" in fullfilename:
-            if '_video_thumbnail' in fullfilename:  # do not add video thumbnail files
-                continue
-            if ext not in {'.po', '.pot'}:
-                files_to_add[fullfilename] = 'Added'
-                continue
-            if ext == '.pot' and filename in rst_files and filename not in files_to_ignore:
-                files_to_add[fullfilename] = 'Added'
-                continue
-            if ext == '.po' and filename in rst_files and filename in pot_files and filename not in files_to_ignore:
-                files_to_add[fullfilename] = 'Added'
-                continue
+        filename = os.path.split(fullfilename)[1]
+        _root, ext = os.path.splitext(filename)
+        if '_video_thumbnail' in fullfilename:
+            files_to_ignore.add(fullfilename)
+        elif status == "??" and fullfilename not in files_to_ignore and fullfilename.startswith(LOCALE_DIR) and fullfilename.endswith('/'):
+            files_to_stage[fullfilename] = 'Added'
+        elif ext not in {'.pot', '.po'}:
+            files_to_ignore.add(fullfilename)
+        elif status == "D":
+            files_to_stage[fullfilename] = 'Deleted'
+        elif status == "??" and '_video_thumbnail' not in fullfilename and fullfilename not in files_to_ignore:
+            files_to_stage[fullfilename] = 'Added'
 
-def parse_git_diff(git_diff: list, files_to_add: dict):
+
+def parse_git_diff(git_diff: list, files_to_stage: dict, files_to_ignore: set):
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     """Parse the git diff response.  Do not add translation files that only have changed
     comment lines or minor changes to headers.
 
     Args:
         git_diff (list): List of lines in the git diff response
-        files_to_add (dict): Dictionary of files to add to git staging
+        files_to_stage (dict): Dictionary of files to add to git staging
+        files_to_ignore (set): Set of files to not add to git staging
     """
-    for line in git_diff:
-        filename = ''
-        line = line.strip()
-        if line.startswith("--- "):
-            filename = line[6:].strip()
+    header_keys = '|'.join([
+        "Project-Id-Version:",
+        "Report-Msgid-Bugs-To:",
+        "POT-Creation-Date:",
+        "PO-Revision-Date:",
+        "Last-Translator:",
+        "Language-Team:",
+        "Language:",
+        "MIME-Version:",
+        "Content-Type:",
+        "Content-Transfer-Encoding:",
+        "Plural-Forms:",
+        "Generated-By:",
+    ])
+    fullfilename = ''
+    filename = ''
+    ext = ''
+    minus = ''
+    plus = ''
+    last = ''
 
-            # Add files not in the locale directory (not translation files)
-            if not filename.startswith(LOCALE_DIR) and filename not in files_to_add:
-                files_to_add[filename] = 'Modified'
+    def process_change(files_to_stage: dict, fullfilename: str, minus: str, plus: str):
+        if (minus or plus) and (SHOW_COMPARISONS > 1 or (SHOW_COMPARISONS == 1 and minus != plus)):
+            print(f"\nCompare: {fullfilename}")
+            print(f"--- {len(minus):,} characters\n\"{minus}\"\n+++ {len(plus):,} characters\n\"{plus}\"")
+        if minus != plus:
+            files_to_stage[fullfilename] = 'Modified'
+        return '', '', ''
+
+    for line in git_diff:
+        # Ignore nearby lines and unchanged ranges
+        if line and line[0] in {' ', '@'}:
             continue
 
-        # Ignore files not identified or already added
-        if not filename or filename in files_to_add:
+        line = line.strip()
+
+        # Ignore selected information lines
+        if not line or line.startswith("+++ ") or line.startswith("diff") or line.startswith("index"):
+            continue
+
+        # Start a new file filename for processing
+        if line.startswith("--- "):
+            minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
+            fullfilename = line[6:].strip()
+            filename = os.path.split(fullfilename)[-1]
+            _root, ext = os.path.splitext(filename)
+
+        # Ignore non-translation files
+        if ext not in {'.pot', '.po'} or not fullfilename.startswith(LOCALE_DIR):
+            continue
+
+        # Ignore files already processed
+        if fullfilename in files_to_stage or fullfilename in files_to_ignore:
+            continue
+
+        # Add changed fuzzy comment lines
+        if re.match(r'[+-]#, fuzzy', line, re.IGNORECASE):
+            minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
+            files_to_stage[fullfilename] = 'Modified'
+            continue
+
+        # Add changed location comment lines
+        if re.match(r'[+-]#: \.\./', line):
+            minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
+            files_to_stage[fullfilename] = 'Modified'
             continue
 
         # Ignore changed comment lines
         if re.match(r'[+-]#', line):
+            minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
             continue
 
         # Ignore changed header lines
-        if re.match(r'[+-]"(POT-Creation|PO-Revision|Language-Team|Plural-Forms|X-Generator|Content-Type|Generated-By|Project-Id-Version)', line):
+        if re.match(r'[+-].*\\n"$', line) or re.match(r'[+-]"(' + header_keys + r')', line, re.IGNORECASE):
+            minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
             continue
 
         # Add files with changed translation text lines
-        if re.match(r'[+-](msgid|msgstr|")', line):
-            files_to_add[filename] = 'Modified'
+        if re.match(r'[+-](msgid|msgstr)', line):
+            minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
+            files_to_stage[fullfilename] = 'Modified'
+            continue
 
+        # Combine changed translation text lines within a 'msgid' or 'msgstr' section to
+        # accommodate lines wrapped at different lengths but the overall content is the same
+        if re.match(r'[+-]"', line):
+            action = line[0]
+            text = line[2:-1]
 
-def initialize_file_sets(rst_files: set, pot_files: set, files_to_ignore: set):
-    """Initialize the file sets.
+            # All related changes in the diff show the removed lines before the added lines
+            # so a minus following a plus should signify a new change.
+            if last == '+' and action == '-':
+                minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
 
-    Args:
-        rst_files (set): Set of *.rst files found
-        pot_files (set): Set of *.pot files found
-        files_to_ignore (set): Set of files not to add to the git staging
-    """
-    for _dirname, _dirlist, filelist in os.walk("."):
-        for filename in filelist:
-            root, ext = os.path.splitext(filename)
-            if ext == '.rst':
-                rst_files.add(root + '.pot')
-            elif ext == '.pot':
-                if filename in rst_files:
-                    pot_files.add(root + '.po')
-                else:
-                    files_to_ignore.add(filename)
-            elif ext == '.po':
-                if filename not in pot_files:
-                    files_to_ignore.add(filename)
+            if action == '+':
+                plus += text
+            else:
+                minus += text
+            last = action
+            continue
+
+        minus, plus, last = process_change(files_to_stage, fullfilename, minus, plus)
+
+    # Handle any outstanding changes at the end of the git diff output
+    process_change(files_to_stage, fullfilename, minus, plus)
 
 
 def main():
     """Main processing method.
     """
-    rst_files = set()
-    pot_files = set()
     files_to_ignore = set()
-
-    # Add standard files not captured by directory walk
-    rst_files.add('sphinx.pot')
-    rst_files.add('sphinx.po')
-
-    print("Getting the list of translation files.")
-    initialize_file_sets(rst_files, pot_files, files_to_ignore)
+    files_to_stage = {}
 
     try:
         command = 'git status --porcelain'
@@ -150,30 +192,34 @@ def main():
     except subprocess.SubprocessError as ex:
         print(f"Error running:{command}\nException: {ex}")
 
-    files_to_add = {}
-    print("Reviewing the changes to identify files to add.")
-
-    print(" - Parsing the git status output.")
-    parse_git_status(git_stat, files_to_add, files_to_ignore, rst_files, pot_files)
+    print("Getting the list of translation files.")
+    print(" - Parsing the git status output")
+    parse_git_status(git_stat, files_to_stage, files_to_ignore)
 
     print(" - Parsing the git diff output.")
-    parse_git_diff(git_diff, files_to_add)
+    parse_git_diff(git_diff, files_to_stage, files_to_ignore)
 
-    if files_to_add:
+    if files_to_stage:
         print("\nFiles to add to git staging:")
-        for filename, action in files_to_add.items():
+        for filename, action in files_to_stage.items():
             print(f" + {filename} [{action}]")
             command = "git add " + filename
-            exit_code = subprocess.run(command, shell=True, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=COMMAND_TIMEOUT).returncode
-            if exit_code:
+            if subprocess.run(
+                    command,
+                    shell=True,
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=COMMAND_TIMEOUT
+                    ).returncode:
                 print("\nThere was a problem adding the file to the commit.\n")
                 sys.exit(1)
+        print()
     else:
-        print("\nNo files to stage for git.")
-
-    print()
+        print("\nNo files to stage for git.\n")
 
 ##############################################################################
+
 
 if __name__ == '__main__':
     main()

--- a/tag_mapping.py
+++ b/tag_mapping.py
@@ -16,6 +16,7 @@ import sys
 
 import xlsxwriter
 
+
 # Column headings to use for the table
 #
 # Each tuple comprises the following:
@@ -1120,7 +1121,7 @@ def rc2cell(row, col):
             cell_col += chr(64 + temp)
         cell_col = cell_col[::-1]
     cell_row = int(max(row, 0)) + 1
-    return '{0}{1}'.format(cell_col, cell_row)
+    return f'{cell_col}{cell_row}'
 
 
 def write_spreadsheet(filename):    # pylint: disable=too-many-locals
@@ -1174,7 +1175,7 @@ def write_spreadsheet(filename):    # pylint: disable=too-many-locals
         row += 1
         text = str(NOTES[num]).replace('``', '')
         text = re.sub(RE_STRIP_URL, r'\1', text)
-        worksheet.write(row, 1, '{0}.  {1}'.format(num, text,))
+        worksheet.write(row, 1, f'{num}.  {text}')
 
     workbook.close()
 
@@ -1236,7 +1237,7 @@ def write_html(filename):
     width = 0
     for (name, val, pts, px) in COLUMNS:    # pylint: disable=unused-variable
         width += px + 15
-    html = '<table width="{0}">\n<tr>\n'.format(width,)
+    html = f'<table width="{width}">\n<tr>\n'
 
     # Write the table headers
     for (name, val, pts, px) in COLUMNS:
@@ -1244,7 +1245,7 @@ def write_html(filename):
         text = re.sub(RE_MAKE_FOOTNOTE, r'<sup><a href="#fn\2">\1</a></sup>', text)
         text = re.sub(RE_MAKE_CODE, r'<code>\1</code>', text)
         text = re.sub(RE_MAKE_ANCHOR, r'<a href="\2">\1</a>', text)
-        html += '  <th style="width: {0}px">{1}</th>\n'.format(px, text)
+        html += f'  <th style="width: {px}px">{text}</th>\n'
     html += '</tr>\n'
 
     # Write the tag values
@@ -1256,9 +1257,9 @@ def write_html(filename):
             text = re.sub(RE_MAKE_CODE, r'<code>\1</code>', text)
             text = re.sub(RE_MAKE_ANCHOR, r'<a href="\2">\1</a>', text)
             if col:
-                html += '  <td>{0}</td>\n'.format(text,)
+                html += f'  <td>{text}</td>\n'
             else:
-                html += '  <td class="column1">{0}</td>\n'.format(text,)
+                html += f'  <td class="column1">{text}</td>\n'
         html += '</tr>\n'
     html += '</table>\n\n'
 
@@ -1268,7 +1269,7 @@ def write_html(filename):
         text = str(NOTES[num]).replace('\n', '<br />')
         text = re.sub(RE_MAKE_CODE, r'<code>\1</code>', text)
         text = re.sub(RE_MAKE_ANCHOR, r'<a href="\2">\1</a>', text)
-        html += '  <li style="width: 1200px;" id="fn{0}">{1}</li>\n'.format(num, text)
+        html += f'  <li style="width: 1200px;" id="fn{num}">{text}</li>\n'
     html += '</ol>\n'
 
     # Write the output file


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [x] Other

### Reason for the Change

There were problems using `sphinx-intl` for updating the `.po` files, so the preferred processer has been changed to `msgmerge` (part  of the standard `gettext` suite) with a fallback to using `sphinx-intl` if `msgmerge` isn't available.

There were problems with the translation file staging script staging files when the only change was the translation strings were wrapped to a different length.  In addition, the processing logic was inefficient.

All python scripts showed errors when analyzed by `isort`, `flake8` and/or `pylint`.

### Description of the Change

General improvements and cleanup of the python scripts:

#### pylintrc:
 - disable deprecated configuration item

#### conf.py:
 - update string formatting to use f-strings
 - remove deprecated utf string type designator

#### setup.py:
 - update string formatting to use f-strings
 - reorganize and refactor code
 - use `msgmerge` for po file updating with `sphinx-intl` as fallback

#### stage_translation_files.py:
 - simplify processing logic
 - limit staged files to only translation files (`*.pot` and `*.po`)
 - combine changed translation lines to accommodate wrapping at different lengths and avoid false positive git staging.
 - update string formatting to use f-strings
 - add option to display the updated lines that trigger a file to be staged

#### tag_mapping.py:
 - update string formatting to use f-strings

#### _extensions/taggerscript.py:
 - reformat imports


### Additional Action Required

None.
