### PR TITLE
PICARD-2741: Modify description of date-related script functions

### DIFF
--- a/_locale/de/LC_MESSAGES/functions/func_dateformat.po
+++ b/_locale/de/LC_MESSAGES/functions/func_dateformat.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-26 10:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_dateformat/de/>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_dateformat/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +26,7 @@ msgid "$dateformat"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:8
-msgid "Usage: **$dateformat(date,[format],[date_order])**"
+msgid "Usage: **$dateformat(date,[format],[date order])**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:9
@@ -46,42 +46,60 @@ msgid ""
 "Returns the input ``date`` in the specified ``format``, which is based on "
 "the standard Python ``strftime`` `format codes <https://strftime.org>`_. If "
 "no ``format`` is specified the date will be returned in the form "
-"'2020-02-15'."
+"'2020-02-15' (year, month, day)."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:18
+#: ../../functions/func_dateformat.rst:16
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\"."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:22
-msgid ""
-"If either the ``date`` or ``format`` are invalid an empty string will be "
-"returned."
+msgid "**mdy** - month, day, year"
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:26
+#: ../../functions/func_dateformat.rst:24
+msgid ""
+"If either the ``date`` or ``format`` are invalid an empty string will be "
+"returned.  If an invalid ``date order`` is specified, the default order "
+"\"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:28
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:31
+#: ../../functions/func_dateformat.rst:32
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:37
-msgid "**Example:**"
+#: ../../functions/func_dateformat.rst:35
+#, fuzzy
+msgid "**Examples:**"
 msgstr "**Beispiel:**"
 
-#: ../../functions/func_dateformat.rst:39
+#: ../../functions/func_dateformat.rst:37
 msgid "The following statements will return the values indicated:"
 msgstr "Die folgenden Ausdrücke geben den angegebenen Wert zurück:"

--- a/_locale/de/LC_MESSAGES/functions/func_datetime.po
+++ b/_locale/de/LC_MESSAGES/functions/func_datetime.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-26 10:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_datetime/de/>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_datetime/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,25 +49,26 @@ msgid ""
 "'2020-02-15 14:26:32'."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:20
+#: ../../functions/func_datetime.rst:18
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:25
+#: ../../functions/func_datetime.rst:22
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:31
-msgid "**Example:**"
+#: ../../functions/func_datetime.rst:25
+#, fuzzy
+msgid "**Examples:**"
 msgstr "**Beispiel:**"
 
-#: ../../functions/func_datetime.rst:33
+#: ../../functions/func_datetime.rst:27
 msgid "The following statements will return the values indicated:"
 msgstr "Die folgenden Ausdrücke geben den angegebenen Wert zurück:"

--- a/_locale/de/LC_MESSAGES/functions/func_day.po
+++ b/_locale/de/LC_MESSAGES/functions/func_day.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-26 10:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_day/de/>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_day/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +26,7 @@ msgid "$day"
 msgstr ""
 
 #: ../../functions/func_day.rst:8
-msgid "Usage: **$day(date[,date_order])**"
+msgid "Usage: **$day(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_day.rst:9
@@ -49,15 +49,37 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_day.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_day.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_day.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:22
-msgid "**Example:**"
-msgstr "**Beispiel:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_day.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_day.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Beispiel:**"
+
+#: ../../functions/func_day.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Die folgenden Ausdrücke geben den angegebenen Wert zurück:"

--- a/_locale/de/LC_MESSAGES/functions/func_month.po
+++ b/_locale/de/LC_MESSAGES/functions/func_month.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-26 10:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_month/de/>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_month/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +26,7 @@ msgid "$month"
 msgstr ""
 
 #: ../../functions/func_month.rst:8
-msgid "Usage: **$month(date[,date_order])**"
+msgid "Usage: **$month(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_month.rst:9
@@ -49,15 +49,37 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_month.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_month.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_month.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:22
-msgid "**Example:**"
-msgstr "**Beispiel:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_month.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_month.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Beispiel:**"
+
+#: ../../functions/func_month.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Die folgenden Ausdrücke geben den angegebenen Wert zurück:"

--- a/_locale/de/LC_MESSAGES/functions/func_year.po
+++ b/_locale/de/LC_MESSAGES/functions/func_year.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-26 10:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_year/de/>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_year/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +26,7 @@ msgid "$year"
 msgstr ""
 
 #: ../../functions/func_year.rst:8
-msgid "Usage: **$year(date[,date_order])**"
+msgid "Usage: **$year(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_year.rst:9
@@ -49,15 +49,37 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_year.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_year.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_year.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:22
-msgid "**Example:**"
-msgstr "**Beispiel:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_year.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_year.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Beispiel:**"
+
+#: ../../functions/func_year.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Die folgenden Ausdrücke geben den angegebenen Wert zurück:"

--- a/_locale/fr/LC_MESSAGES/functions/func_dateformat.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_dateformat.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-31 06:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: French <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_dateformat/fr/>\n"
+"Language-Team: French <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_dateformat/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,7 +27,8 @@ msgid "$dateformat"
 msgstr "$dateformat"
 
 #: ../../functions/func_dateformat.rst:8
-msgid "Usage: **$dateformat(date,[format],[date_order])**"
+#, fuzzy
+msgid "Usage: **$dateformat(date,[format],[date order])**"
 msgstr "Utilisation: **$dateformat(date,[format],[ordre_des_dates])**"
 
 #: ../../functions/func_dateformat.rst:9
@@ -43,38 +44,58 @@ msgid "**Description:**"
 msgstr "**Description:**"
 
 #: ../../functions/func_dateformat.rst:14
+#, fuzzy
 msgid ""
 "Returns the input ``date`` in the specified ``format``, which is based on "
 "the standard Python ``strftime`` `format codes <https://strftime.org>`_. If "
 "no ``format`` is specified the date will be returned in the form "
-"'2020-02-15'."
+"'2020-02-15' (year, month, day)."
 msgstr ""
 "Renvoie la ``date`` d'entrée dans le ``format`` spécifié, qui est basé sur "
 "les codes de format standard Python ``strftime`` `<https://strftime.org>`_. "
 "Si aucun ``format`` n'est spécifié, la date sera retournée sous la forme "
 "'2020-02-15'."
 
-#: ../../functions/func_dateformat.rst:18
+#: ../../functions/func_dateformat.rst:16
+#, fuzzy
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\"."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
 msgstr ""
 "Les parties \"année\", \"mois\" et \"jour\" de la date doivent être saisies "
 "sous forme de chiffres et peuvent être séparées par des caractères non "
 "numériques.  L'ordre par défaut de la date saisie est \"ymd\".  Ceci peut "
 "être changé en spécifiant un \"ordre_de_date\" de \"dmy\" ou \"mdy\"."
 
+#: ../../functions/func_dateformat.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:21
+msgid "**dmy** - day, month, year"
+msgstr ""
+
 #: ../../functions/func_dateformat.rst:22
+msgid "**mdy** - month, day, year"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:24
+#, fuzzy
 msgid ""
 "If either the ``date`` or ``format`` are invalid an empty string will be "
-"returned."
+"returned.  If an invalid ``date order`` is specified, the default order "
+"\"ymd\" will be used."
 msgstr ""
 "Si la ``date`` ou le ``format`` ne sont pas valides, une chaîne vide sera "
 "retournée."
 
-#: ../../functions/func_dateformat.rst:26
+#: ../../functions/func_dateformat.rst:28
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
@@ -82,13 +103,14 @@ msgstr ""
 "Tous les caractères spéciaux tels que \"%\", \"$\", \"(\", \")\" et \"\\\\\" "
 "devront être échappés comme indiqué dans les exemples ci-dessous."
 
-#: ../../functions/func_dateformat.rst:31
+#: ../../functions/func_dateformat.rst:32
+#, fuzzy
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 "Les codes de formatage spécifiques à la plate-forme doivent être évités pour "
 "garantir la portabilité des scripts sur les différentes plates-formes. Ces "
@@ -97,10 +119,11 @@ msgstr ""
 "spécificateurs de longueur d'élément (par exemple: ``%3Y``); et accrocher "
 "'%' à la fin de la chaîne de format."
 
-#: ../../functions/func_dateformat.rst:37
-msgid "**Example:**"
+#: ../../functions/func_dateformat.rst:35
+#, fuzzy
+msgid "**Examples:**"
 msgstr "**Exemple:**"
 
-#: ../../functions/func_dateformat.rst:39
+#: ../../functions/func_dateformat.rst:37
 msgid "The following statements will return the values indicated:"
 msgstr "Les instructions suivantes renverront les valeurs indiquées :"

--- a/_locale/fr/LC_MESSAGES/functions/func_datetime.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_datetime.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-02-13 16:14+0000\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language-Team: French <https://translate.uploadedlobster.com/projects/picard-"
@@ -53,7 +53,7 @@ msgstr ""
 "org>`_. Si aucun format n'est spécifié, la date et l'heure seront retournées "
 "sous la forme '2020-02-15 14:26:32'."
 
-#: ../../functions/func_datetime.rst:20
+#: ../../functions/func_datetime.rst:18
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
@@ -61,13 +61,14 @@ msgstr ""
 "Tous les caractères spéciaux tels que \"%\", \"$\", \"(\", \")\" et \"\\\\\" "
 "devront être échappés comme indiqué dans les exemples ci-dessous."
 
-#: ../../functions/func_datetime.rst:25
+#: ../../functions/func_datetime.rst:22
+#, fuzzy
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 "Les codes de formatage spécifiques à la plate-forme doivent être évités pour "
 "garantir la portabilité des scripts sur les différentes plates-formes. Ces "
@@ -76,10 +77,11 @@ msgstr ""
 "spécificateurs de longueur d'élément (par exemple: ``%3Y``); et accrocher "
 "'%' à la fin de la chaîne de format."
 
-#: ../../functions/func_datetime.rst:31
-msgid "**Example:**"
+#: ../../functions/func_datetime.rst:25
+#, fuzzy
+msgid "**Examples:**"
 msgstr "**Exemple:**"
 
-#: ../../functions/func_datetime.rst:33
+#: ../../functions/func_datetime.rst:27
 msgid "The following statements will return the values indicated:"
 msgstr "Les instructions suivantes renverront les valeurs indiquées :"

--- a/_locale/fr/LC_MESSAGES/functions/func_day.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_day.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-31 06:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: French <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_day/fr/>\n"
+"Language-Team: French <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_day/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,7 +27,8 @@ msgid "$day"
 msgstr "$day"
 
 #: ../../functions/func_day.rst:8
-msgid "Usage: **$day(date[,date_order])**"
+#, fuzzy
+msgid "Usage: **$day(date[,date order])**"
 msgstr "Utilisation : **$day(date[,ordre_des_dates])**"
 
 #: ../../functions/func_day.rst:9
@@ -47,12 +48,12 @@ msgid "Returns the \"day\" portion of the input ``date``."
 msgstr "Renvoie la partie \"jour\" de la ``date`` d'entrée."
 
 #: ../../functions/func_day.rst:16
+#, fuzzy
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
 msgstr ""
 "Les parties \"année\", \"mois\" et \"jour\" de la date doivent être saisies "
 "sous forme de chiffres et peuvent être séparées par des caractères non "
@@ -61,10 +62,33 @@ msgstr ""
 "quelque chose d'autre que \"ymd\", \"dmy\" ou \"mdy\" est spécifié, l'ordre "
 "par défaut \"ymd\" sera utilisé."
 
+#: ../../functions/func_day.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_day.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_day.rst:21
+msgid "**dmy** - day, month, year"
+msgstr ""
+
 #: ../../functions/func_day.rst:22
-msgid "**Example:**"
-msgstr "**Exemple:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_day.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_day.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Exemple:**"
+
+#: ../../functions/func_day.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Les instructions suivantes renverront les valeurs indiquées :"

--- a/_locale/fr/LC_MESSAGES/functions/func_month.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_month.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-31 06:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: French <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_month/fr/>\n"
+"Language-Team: French <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_month/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,7 +27,8 @@ msgid "$month"
 msgstr "$month"
 
 #: ../../functions/func_month.rst:8
-msgid "Usage: **$month(date[,date_order])**"
+#, fuzzy
+msgid "Usage: **$month(date[,date order])**"
 msgstr "Utilisation : **$month(date[,ordre_des_dates])**"
 
 #: ../../functions/func_month.rst:9
@@ -47,12 +48,12 @@ msgid "Returns the \"month\" portion of the input ``date``."
 msgstr "Renvoie la partie \"mois\" de la ``date`` d'entrée."
 
 #: ../../functions/func_month.rst:16
+#, fuzzy
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
 msgstr ""
 "Les parties \"année\", \"mois\" et \"jour\" de la date doivent être saisies "
 "sous forme de chiffres et peuvent être séparées par des caractères non "
@@ -61,10 +62,33 @@ msgstr ""
 "quelque chose d'autre que \"ymd\", \"dmy\" ou \"mdy\" est spécifié, l'ordre "
 "par défaut \"ymd\" sera utilisé."
 
+#: ../../functions/func_month.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_month.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_month.rst:21
+msgid "**dmy** - day, month, year"
+msgstr ""
+
 #: ../../functions/func_month.rst:22
-msgid "**Example:**"
-msgstr "**Exemple:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_month.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_month.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Exemple:**"
+
+#: ../../functions/func_month.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Les instructions suivantes renverront les valeurs indiquées :"

--- a/_locale/fr/LC_MESSAGES/functions/func_year.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_year.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2023-08-31 06:27+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: French <https://translations.metabrainz.org/projects/"
-"picard-docs/functionsfunc_year/fr/>\n"
+"Language-Team: French <https://translations.metabrainz.org/projects/picard-"
+"docs/functionsfunc_year/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,7 +27,8 @@ msgid "$year"
 msgstr "$year"
 
 #: ../../functions/func_year.rst:8
-msgid "Usage: **$year(date[,date_order])**"
+#, fuzzy
+msgid "Usage: **$year(date[,date order])**"
 msgstr "Utilisation : **$year(date[,ordre_des_dates])**"
 
 #: ../../functions/func_year.rst:9
@@ -47,12 +48,12 @@ msgid "Returns the \"year\" portion of the input ``date``."
 msgstr "Renvoie la partie \"année\" de la ``date`` d'entrée."
 
 #: ../../functions/func_year.rst:16
+#, fuzzy
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
 msgstr ""
 "Les parties \"année\", \"mois\" et \"jour\" de la date doivent être saisies "
 "sous forme de chiffres et peuvent être séparées par des caractères non "
@@ -61,10 +62,33 @@ msgstr ""
 "quelque chose d'autre que \"ymd\", \"dmy\" ou \"mdy\" est spécifié, l'ordre "
 "par défaut \"ymd\" sera utilisé."
 
+#: ../../functions/func_year.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_year.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_year.rst:21
+msgid "**dmy** - day, month, year"
+msgstr ""
+
 #: ../../functions/func_year.rst:22
-msgid "**Example:**"
-msgstr "**Exemple:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_year.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_year.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Exemple:**"
+
+#: ../../functions/func_year.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Les instructions suivantes renverront les valeurs indiquées :"

--- a/_locale/gettext/functions/func_dateformat.pot
+++ b/_locale/gettext/functions/func_dateformat.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgid "$dateformat"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:8
-msgid "Usage: **$dateformat(date,[format],[date_order])**"
+msgid "Usage: **$dateformat(date,[format],[date order])**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:9
@@ -37,29 +37,45 @@ msgid "**Description:**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:14
-msgid "Returns the input ``date`` in the specified ``format``, which is based on the standard Python ``strftime`` `format codes <https://strftime.org>`_. If no ``format`` is specified the date will be returned in the form '2020-02-15'."
+msgid "Returns the input ``date`` in the specified ``format``, which is based on the standard Python ``strftime`` `format codes <https://strftime.org>`_. If no ``format`` is specified the date will be returned in the form '2020-02-15' (year, month, day)."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:16
+msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\" (year, month, day).  This can be changed by specifying a ``date order``."
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:18
-msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\".  This can be changed by specifying a ``date_order`` of either \"dmy\" or \"mdy\"."
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:22
-msgid "If either the ``date`` or ``format`` are invalid an empty string will be returned."
+msgid "**mdy** - month, day, year"
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:26
+#: ../../functions/func_dateformat.rst:24
+msgid "If either the ``date`` or ``format`` are invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:28
 msgid "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:31
-msgid "Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string."
+#: ../../functions/func_dateformat.rst:32
+msgid "Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:35
+msgid "**Examples:**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:37
-msgid "**Example:**"
-msgstr ""
-
-#: ../../functions/func_dateformat.rst:39
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/gettext/functions/func_datetime.pot
+++ b/_locale/gettext/functions/func_datetime.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,18 +40,18 @@ msgstr ""
 msgid "Returns the current date and time in the specified format, which is based on the standard Python ``strftime`` `format codes <https://strftime.org>`_. If no format is specified the date and time will be returned in the form '2020-02-15 14:26:32'."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:20
+#: ../../functions/func_datetime.rst:18
 msgid "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be escaped as shown in the examples below."
 msgstr ""
 
+#: ../../functions/func_datetime.rst:22
+msgid "Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string."
+msgstr ""
+
 #: ../../functions/func_datetime.rst:25
-msgid "Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string."
+msgid "**Examples:**"
 msgstr ""
 
-#: ../../functions/func_datetime.rst:31
-msgid "**Example:**"
-msgstr ""
-
-#: ../../functions/func_datetime.rst:33
+#: ../../functions/func_datetime.rst:27
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/gettext/functions/func_day.pot
+++ b/_locale/gettext/functions/func_day.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgid "$day"
 msgstr ""
 
 #: ../../functions/func_day.rst:8
-msgid "Usage: **$day(date[,date_order])**"
+msgid "Usage: **$day(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_day.rst:9
@@ -41,13 +41,33 @@ msgid "Returns the \"day\" portion of the input ``date``."
 msgstr ""
 
 #: ../../functions/func_day.rst:16
-msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\".  This can be changed by specifying a ``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\" (year, month, day).  This can be changed by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_day.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_day.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_day.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:24
+msgid "If the ``date`` is invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_day.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_day.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/gettext/functions/func_month.pot
+++ b/_locale/gettext/functions/func_month.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgid "$month"
 msgstr ""
 
 #: ../../functions/func_month.rst:8
-msgid "Usage: **$month(date[,date_order])**"
+msgid "Usage: **$month(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_month.rst:9
@@ -41,13 +41,33 @@ msgid "Returns the \"month\" portion of the input ``date``."
 msgstr ""
 
 #: ../../functions/func_month.rst:16
-msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\".  This can be changed by specifying a ``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\" (year, month, day).  This can be changed by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_month.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_month.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_month.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:24
+msgid "If the ``date`` is invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_month.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_month.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/gettext/functions/func_year.pot
+++ b/_locale/gettext/functions/func_year.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgid "$year"
 msgstr ""
 
 #: ../../functions/func_year.rst:8
-msgid "Usage: **$year(date[,date_order])**"
+msgid "Usage: **$year(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_year.rst:9
@@ -41,13 +41,33 @@ msgid "Returns the \"year\" portion of the input ``date``."
 msgstr ""
 
 #: ../../functions/func_year.rst:16
-msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\".  This can be changed by specifying a ``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+msgid "The \"year\", \"month\" and \"day\" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is \"ymd\" (year, month, day).  This can be changed by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_year.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_year.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_year.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:24
+msgid "If the ``date`` is invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_year.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_year.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/functions/func_dateformat.po
+++ b/_locale/nb_NO/LC_MESSAGES/functions/func_dateformat.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -24,7 +24,7 @@ msgid "$dateformat"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:8
-msgid "Usage: **$dateformat(date,[format],[date_order])**"
+msgid "Usage: **$dateformat(date,[format],[date order])**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:9
@@ -44,42 +44,59 @@ msgid ""
 "Returns the input ``date`` in the specified ``format``, which is based on "
 "the standard Python ``strftime`` `format codes <https://strftime.org>`_. If "
 "no ``format`` is specified the date will be returned in the form "
-"'2020-02-15'."
+"'2020-02-15' (year, month, day)."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:18
+#: ../../functions/func_dateformat.rst:16
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\"."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:22
-msgid ""
-"If either the ``date`` or ``format`` are invalid an empty string will be "
-"returned."
+msgid "**mdy** - month, day, year"
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:26
+#: ../../functions/func_dateformat.rst:24
+msgid ""
+"If either the ``date`` or ``format`` are invalid an empty string will be "
+"returned.  If an invalid ``date order`` is specified, the default order "
+"\"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:28
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:31
+#: ../../functions/func_dateformat.rst:32
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:35
+msgid "**Examples:**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:37
-msgid "**Example:**"
-msgstr ""
-
-#: ../../functions/func_dateformat.rst:39
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/functions/func_datetime.po
+++ b/_locale/nb_NO/LC_MESSAGES/functions/func_datetime.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,25 +47,25 @@ msgid ""
 "'2020-02-15 14:26:32'."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:20
+#: ../../functions/func_datetime.rst:18
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:25
+#: ../../functions/func_datetime.rst:22
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:31
-msgid "**Example:**"
+#: ../../functions/func_datetime.rst:25
+msgid "**Examples:**"
 msgstr ""
 
-#: ../../functions/func_datetime.rst:33
+#: ../../functions/func_datetime.rst:27
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/functions/func_day.po
+++ b/_locale/nb_NO/LC_MESSAGES/functions/func_day.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,7 +21,7 @@ msgid "$day"
 msgstr ""
 
 #: ../../functions/func_day.rst:8
-msgid "Usage: **$day(date[,date_order])**"
+msgid "Usage: **$day(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_day.rst:9
@@ -44,15 +44,36 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_day.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_day.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_day.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_day.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_day.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/functions/func_month.po
+++ b/_locale/nb_NO/LC_MESSAGES/functions/func_month.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,7 +21,7 @@ msgid "$month"
 msgstr ""
 
 #: ../../functions/func_month.rst:8
-msgid "Usage: **$month(date[,date_order])**"
+msgid "Usage: **$month(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_month.rst:9
@@ -44,15 +44,36 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_month.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_month.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_month.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_month.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_month.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/functions/func_year.po
+++ b/_locale/nb_NO/LC_MESSAGES/functions/func_year.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,7 +21,7 @@ msgid "$year"
 msgstr ""
 
 #: ../../functions/func_year.rst:8
-msgid "Usage: **$year(date[,date_order])**"
+msgid "Usage: **$year(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_year.rst:9
@@ -44,15 +44,36 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_year.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_year.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_year.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_year.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_year.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nl/LC_MESSAGES/functions/func_dateformat.po
+++ b/_locale/nl/LC_MESSAGES/functions/func_dateformat.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -24,7 +24,7 @@ msgid "$dateformat"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:8
-msgid "Usage: **$dateformat(date,[format],[date_order])**"
+msgid "Usage: **$dateformat(date,[format],[date order])**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:9
@@ -44,42 +44,59 @@ msgid ""
 "Returns the input ``date`` in the specified ``format``, which is based on "
 "the standard Python ``strftime`` `format codes <https://strftime.org>`_. If "
 "no ``format`` is specified the date will be returned in the form "
-"'2020-02-15'."
+"'2020-02-15' (year, month, day)."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:18
+#: ../../functions/func_dateformat.rst:16
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\"."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:22
-msgid ""
-"If either the ``date`` or ``format`` are invalid an empty string will be "
-"returned."
+msgid "**mdy** - month, day, year"
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:26
+#: ../../functions/func_dateformat.rst:24
+msgid ""
+"If either the ``date`` or ``format`` are invalid an empty string will be "
+"returned.  If an invalid ``date order`` is specified, the default order "
+"\"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:28
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:31
+#: ../../functions/func_dateformat.rst:32
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:35
+msgid "**Examples:**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:37
-msgid "**Example:**"
-msgstr ""
-
-#: ../../functions/func_dateformat.rst:39
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nl/LC_MESSAGES/functions/func_datetime.po
+++ b/_locale/nl/LC_MESSAGES/functions/func_datetime.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,25 +47,25 @@ msgid ""
 "'2020-02-15 14:26:32'."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:20
+#: ../../functions/func_datetime.rst:18
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:25
+#: ../../functions/func_datetime.rst:22
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:31
-msgid "**Example:**"
+#: ../../functions/func_datetime.rst:25
+msgid "**Examples:**"
 msgstr ""
 
-#: ../../functions/func_datetime.rst:33
+#: ../../functions/func_datetime.rst:27
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nl/LC_MESSAGES/functions/func_day.po
+++ b/_locale/nl/LC_MESSAGES/functions/func_day.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,7 +21,7 @@ msgid "$day"
 msgstr ""
 
 #: ../../functions/func_day.rst:8
-msgid "Usage: **$day(date[,date_order])**"
+msgid "Usage: **$day(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_day.rst:9
@@ -44,15 +44,36 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_day.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_day.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_day.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_day.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_day.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nl/LC_MESSAGES/functions/func_month.po
+++ b/_locale/nl/LC_MESSAGES/functions/func_month.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,7 +21,7 @@ msgid "$month"
 msgstr ""
 
 #: ../../functions/func_month.rst:8
-msgid "Usage: **$month(date[,date_order])**"
+msgid "Usage: **$month(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_month.rst:9
@@ -44,15 +44,36 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_month.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_month.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_month.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_month.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_month.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/nl/LC_MESSAGES/functions/func_year.po
+++ b/_locale/nl/LC_MESSAGES/functions/func_year.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,7 +21,7 @@ msgid "$year"
 msgstr ""
 
 #: ../../functions/func_year.rst:8
-msgid "Usage: **$year(date[,date_order])**"
+msgid "Usage: **$year(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_year.rst:9
@@ -44,15 +44,36 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_year.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_year.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_year.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:22
-msgid "**Example:**"
+msgid "**mdy** - month, day, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_year.rst:27
+msgid "**Examples:**"
+msgstr ""
+
+#: ../../functions/func_year.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr ""

--- a/_locale/pt_BR/LC_MESSAGES/functions/func_dateformat.po
+++ b/_locale/pt_BR/LC_MESSAGES/functions/func_dateformat.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2021-12-04 08:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.uploadedlobster.com/"
@@ -25,7 +25,7 @@ msgid "$dateformat"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:8
-msgid "Usage: **$dateformat(date,[format],[date_order])**"
+msgid "Usage: **$dateformat(date,[format],[date order])**"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:9
@@ -45,42 +45,60 @@ msgid ""
 "Returns the input ``date`` in the specified ``format``, which is based on "
 "the standard Python ``strftime`` `format codes <https://strftime.org>`_. If "
 "no ``format`` is specified the date will be returned in the form "
-"'2020-02-15'."
+"'2020-02-15' (year, month, day)."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:18
+#: ../../functions/func_dateformat.rst:16
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\"."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_dateformat.rst:22
-msgid ""
-"If either the ``date`` or ``format`` are invalid an empty string will be "
-"returned."
+msgid "**mdy** - month, day, year"
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:26
+#: ../../functions/func_dateformat.rst:24
+msgid ""
+"If either the ``date`` or ``format`` are invalid an empty string will be "
+"returned.  If an invalid ``date order`` is specified, the default order "
+"\"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_dateformat.rst:28
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:31
+#: ../../functions/func_dateformat.rst:32
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 
-#: ../../functions/func_dateformat.rst:37
-msgid "**Example:**"
+#: ../../functions/func_dateformat.rst:35
+#, fuzzy
+msgid "**Examples:**"
 msgstr "**Exemplo:**"
 
-#: ../../functions/func_dateformat.rst:39
+#: ../../functions/func_dateformat.rst:37
 msgid "The following statements will return the values indicated:"
 msgstr "Os comandos a seguir retornarão os valores indicados:"

--- a/_locale/pt_BR/LC_MESSAGES/functions/func_datetime.po
+++ b/_locale/pt_BR/LC_MESSAGES/functions/func_datetime.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 08:15-0700\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2021-08-23 07:21+0000\n"
 "Last-Translator: Gabriel Ferreira <gabrielcarvfer@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.uploadedlobster.com/"
@@ -47,25 +47,26 @@ msgid ""
 "'2020-02-15 14:26:32'."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:20
+#: ../../functions/func_datetime.rst:18
 msgid ""
 "Any special characters such as '%', '$', '(', ')' and '\\\\' will need to be "
 "escaped as shown in the examples below."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:25
+#: ../../functions/func_datetime.rst:22
 msgid ""
 "Platform-specific formatting codes should be avoided to help ensure the "
 "portability of scripts across the different platforms.  These codes include: "
 "remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their "
-"equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: "
-"``%3Y``); and hanging '%' at the end of the format string."
+"equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e."
+"g.: ``%3Y``); and hanging '%' at the end of the format string."
 msgstr ""
 
-#: ../../functions/func_datetime.rst:31
-msgid "**Example:**"
+#: ../../functions/func_datetime.rst:25
+#, fuzzy
+msgid "**Examples:**"
 msgstr "**Exemplo:**"
 
-#: ../../functions/func_datetime.rst:33
+#: ../../functions/func_datetime.rst:27
 msgid "The following statements will return the values indicated:"
 msgstr "Os comandos a seguir retornarão os valores indicados:"

--- a/_locale/pt_BR/LC_MESSAGES/functions/func_day.po
+++ b/_locale/pt_BR/LC_MESSAGES/functions/func_day.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2021-12-02 08:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.uploadedlobster.com/"
@@ -26,7 +26,7 @@ msgid "$day"
 msgstr ""
 
 #: ../../functions/func_day.rst:8
-msgid "Usage: **$day(date[,date_order])**"
+msgid "Usage: **$day(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_day.rst:9
@@ -49,15 +49,37 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_day.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_day.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_day.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_day.rst:22
-msgid "**Example:**"
-msgstr "**Exemplo:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_day.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_day.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Exemplo:**"
+
+#: ../../functions/func_day.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Os comandos a seguir retornarão os valores indicados:"

--- a/_locale/pt_BR/LC_MESSAGES/functions/func_month.po
+++ b/_locale/pt_BR/LC_MESSAGES/functions/func_month.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2021-11-30 14:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.uploadedlobster.com/"
@@ -26,7 +26,7 @@ msgid "$month"
 msgstr ""
 
 #: ../../functions/func_month.rst:8
-msgid "Usage: **$month(date[,date_order])**"
+msgid "Usage: **$month(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_month.rst:9
@@ -49,15 +49,37 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_month.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_month.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_month.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_month.rst:22
-msgid "**Example:**"
-msgstr "**Exemplo:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_month.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_month.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Exemplo:**"
+
+#: ../../functions/func_month.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Os comandos a seguir retornarão os valores indicados:"

--- a/_locale/pt_BR/LC_MESSAGES/functions/func_year.po
+++ b/_locale/pt_BR/LC_MESSAGES/functions/func_year.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-08-31 13:31-0600\n"
 "PO-Revision-Date: 2021-12-02 08:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.uploadedlobster.com/"
@@ -26,7 +26,7 @@ msgid "$year"
 msgstr ""
 
 #: ../../functions/func_year.rst:8
-msgid "Usage: **$year(date[,date_order])**"
+msgid "Usage: **$year(date[,date order])**"
 msgstr ""
 
 #: ../../functions/func_year.rst:9
@@ -49,15 +49,37 @@ msgstr ""
 msgid ""
 "The \"year\", \"month\" and \"day\" portions of the date must be entered as "
 "numbers, and can be separated by any non-numeric characters.  The default "
-"order for the input date is \"ymd\".  This can be changed by specifying a "
-"``date_order`` of either \"dmy\" or \"mdy\".  If anything other than \"ymd"
-"\", \"dmy\" or \"mdy\" is specified, the default order \"ymd\" will be used."
+"order for the input date is \"ymd\" (year, month, day).  This can be changed "
+"by specifying a ``date order``."
+msgstr ""
+
+#: ../../functions/func_year.rst:18
+msgid "Valid entries for ``date order`` are:"
+msgstr ""
+
+#: ../../functions/func_year.rst:20
+msgid "**ymd** - year, month, day (This is the default order.)"
+msgstr ""
+
+#: ../../functions/func_year.rst:21
+msgid "**dmy** - day, month, year"
 msgstr ""
 
 #: ../../functions/func_year.rst:22
-msgid "**Example:**"
-msgstr "**Exemplo:**"
+msgid "**mdy** - month, day, year"
+msgstr ""
 
 #: ../../functions/func_year.rst:24
+msgid ""
+"If the ``date`` is invalid an empty string will be returned.  If an invalid "
+"``date order`` is specified, the default order \"ymd\" will be used."
+msgstr ""
+
+#: ../../functions/func_year.rst:27
+#, fuzzy
+msgid "**Examples:**"
+msgstr "**Exemplo:**"
+
+#: ../../functions/func_year.rst:29
 msgid "The following statements will return the values indicated:"
 msgstr "Os comandos a seguir retornarão os valores indicados:"

--- a/functions/func_dateformat.rst
+++ b/functions/func_dateformat.rst
@@ -29,7 +29,7 @@ If either the ``date`` or ``format`` are invalid an empty string will be returne
 
 .. warning::
 
-   Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string.
+   Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string.
 
 
 **Examples:**

--- a/functions/func_dateformat.rst
+++ b/functions/func_dateformat.rst
@@ -5,36 +5,34 @@
 $dateformat
 ===========
 
-| Usage: **$dateformat(date,[format],[date_order])**
+| Usage: **$dateformat(date,[format],[date order])**
 | Category: information
 | Implemented: Picard 2.7
 
 **Description:**
 
-Returns the input ``date`` in the specified ``format``, which is based on the
-standard Python ``strftime`` `format codes <https://strftime.org>`_. If no ``format`` is specified
-the date will be returned in the form '2020-02-15'.
+Returns the input ``date`` in the specified ``format``, which is based on the standard Python ``strftime`` `format codes <https://strftime.org>`_. If no ``format`` is specified the date will be returned in the form '2020-02-15' (year, month, day).
 
-The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated
-by any non-numeric characters.  The default order for the input date is "ymd".  This can be changed
-by specifying a ``date_order`` of either "dmy" or "mdy".
+The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is "ymd" (year, month, day).  This can be changed by specifying a ``date order``.
 
-If either the ``date`` or ``format`` are invalid an empty string will be returned.
+Valid entries for ``date order`` are:
+
+- **ymd** - year, month, day (This is the default order.)
+- **dmy** - day, month, year
+- **mdy** - month, day, year
+
+If either the ``date`` or ``format`` are invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order "ymd" will be used.
 
 .. note::
 
-   Any special characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the
-   examples below.
+   Any special characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the examples below.
 
 .. warning::
 
-   Platform-specific formatting codes should be avoided to help ensure the portability
-   of scripts across the different platforms.  These codes include: remove zero-padding (e.g.:
-   ``%-d`` and ``%-m`` on Linux or macOS, and their equivalent ``%#d`` and ``%#m`` on Windows);
-   element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string.
+   Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalent ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string.
 
 
-**Example:**
+**Examples:**
 
 The following statements will return the values indicated:
 

--- a/functions/func_datetime.rst
+++ b/functions/func_datetime.rst
@@ -11,24 +11,18 @@ $datetime
 
 **Description:**
 
-Returns the current date and time in the specified format, which is based on the
-standard Python ``strftime`` `format codes <https://strftime.org>`_. If no format is specified
-the date and time will be returned in the form '2020-02-15 14:26:32'.
+Returns the current date and time in the specified format, which is based on the standard Python ``strftime`` `format codes <https://strftime.org>`_. If no format is specified the date and time will be returned in the form '2020-02-15 14:26:32'.
 
 .. note::
 
-   Any special characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the
-   examples below.
+   Any special characters such as '%', '$', '(', ')' and '\\' will need to be escaped as shown in the examples below.
 
 .. warning::
 
-   Platform-specific formatting codes should be avoided to help ensure the portability
-   of scripts across the different platforms.  These codes include: remove zero-padding (e.g.:
-   ``%-d`` and ``%-m`` on Linux or macOS, and their equivalent ``%#d`` and ``%#m`` on Windows);
-   element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string.
+   Platform-specific formatting codes should be avoided to help ensure the portability of scripts across the different platforms.  These codes include: remove zero-padding (e.g.: ``%-d`` and ``%-m`` on Linux or macOS, and their equivalents ``%#d`` and ``%#m`` on Windows); element length specifiers (e.g.: ``%3Y``); and hanging '%' at the end of the format string.
 
 
-**Example:**
+**Examples:**
 
 The following statements will return the values indicated:
 

--- a/functions/func_day.rst
+++ b/functions/func_day.rst
@@ -5,7 +5,7 @@
 $day
 ====
 
-| Usage: **$day(date[,date_order])**
+| Usage: **$day(date[,date order])**
 | Category: information
 | Implemented: Picard 2.7
 
@@ -13,13 +13,18 @@ $day
 
 Returns the "day" portion of the input ``date``.
 
-The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated
-by any non-numeric characters.  The default order for the input date is "ymd".  This can be changed
-by specifying a ``date_order`` of either "dmy" or "mdy".  If anything other than "ymd", "dmy" or
-"mdy" is specified, the default order "ymd" will be used.
+The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is "ymd" (year, month, day).  This can be changed by specifying a ``date order``.
+
+Valid entries for ``date order`` are:
+
+- **ymd** - year, month, day (This is the default order.)
+- **dmy** - day, month, year
+- **mdy** - month, day, year
+
+If the ``date`` is invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order "ymd" will be used.
 
 
-**Example:**
+**Examples:**
 
 The following statements will return the values indicated:
 

--- a/functions/func_month.rst
+++ b/functions/func_month.rst
@@ -5,7 +5,7 @@
 $month
 ======
 
-| Usage: **$month(date[,date_order])**
+| Usage: **$month(date[,date order])**
 | Category: information
 | Implemented: Picard 2.7
 
@@ -13,13 +13,18 @@ $month
 
 Returns the "month" portion of the input ``date``.
 
-The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated
-by any non-numeric characters.  The default order for the input date is "ymd".  This can be changed
-by specifying a ``date_order`` of either "dmy" or "mdy".  If anything other than "ymd", "dmy" or
-"mdy" is specified, the default order "ymd" will be used.
+The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is "ymd" (year, month, day).  This can be changed by specifying a ``date order``.
+
+Valid entries for ``date order`` are:
+
+- **ymd** - year, month, day (This is the default order.)
+- **dmy** - day, month, year
+- **mdy** - month, day, year
+
+If the ``date`` is invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order "ymd" will be used.
 
 
-**Example:**
+**Examples:**
 
 The following statements will return the values indicated:
 

--- a/functions/func_year.rst
+++ b/functions/func_year.rst
@@ -5,7 +5,7 @@
 $year
 =====
 
-| Usage: **$year(date[,date_order])**
+| Usage: **$year(date[,date order])**
 | Category: information
 | Implemented: Picard 2.7
 
@@ -13,13 +13,18 @@ $year
 
 Returns the "year" portion of the input ``date``.
 
-The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated
-by any non-numeric characters.  The default order for the input date is "ymd".  This can be changed
-by specifying a ``date_order`` of either "dmy" or "mdy".  If anything other than "ymd", "dmy" or
-"mdy" is specified, the default order "ymd" will be used.
+The "year", "month" and "day" portions of the date must be entered as numbers, and can be separated by any non-numeric characters.  The default order for the input date is "ymd" (year, month, day).  This can be changed by specifying a ``date order``.
+
+Valid entries for ``date order`` are:
+
+- **ymd** - year, month, day (This is the default order.)
+- **dmy** - day, month, year
+- **mdy** - month, day, year
+
+If the ``date`` is invalid an empty string will be returned.  If an invalid ``date order`` is specified, the default order "ymd" will be used.
 
 
-**Example:**
+**Examples:**
 
 The following statements will return the values indicated:
 


### PR DESCRIPTION

### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [x] Other

### Reason for the Change

Some scripting functions accept an option to specify the order of year, month and day for the input.  These are currently indicated in the description as "ymd", "dmy", etc. which are not intuitive when translated into other languages.  Suggest updating the description to indicate the available options such as "ymd" which should not be translated, along with a long description of the order which should be translated.  For example:

`"ymd" = "year", "month" and "day" order`

would translate to French as something like:

`"ymd" = Ordre "année", "mois" et "jour"`

This ensures that the ordering argument expected by Picard remains the same for all languages, but its meaning is made clear in the translations.

### Description of the Change

Update the descriptions for the `$dateformat()`, `$day()`, `$month()` and `$year()` scripting functions.

### Additional Action Required

Once merged, the translation files (.pot and .po) will need to be updated.
