### PR TITLE
Update command line options

### DIFF
--- a/_locale/de/LC_MESSAGES/appendices/command_line.po
+++ b/_locale/de/LC_MESSAGES/appendices/command_line.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 15:29-0700\n"
+"POT-Creation-Date: 2023-09-20 08:43-0600\n"
 "PO-Revision-Date: 2023-08-31 19:39+0000\n"
 "Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
-"Language-Team: German <https://translations.metabrainz.org/projects/"
-"picard-docs/appendicescommand_line/de/>\n"
+"Language-Team: German <https://translations.metabrainz.org/projects/picard-"
+"docs/appendicescommand_line/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,14 +43,21 @@ msgid "show a help message and exit"
 msgstr "Hilfe anzeigen und beenden"
 
 #: ../../appendices/command_line.rst:20
+msgid ""
+"audit events passed as a comma-separated list, prefixes supported, use "
+"\"all\" to match any event. See the `Python Documentation <https://docs."
+"python.org/3/library/audit_events.html#audit-events>`_ for more information."
+msgstr ""
+
+#: ../../appendices/command_line.rst:24
 msgid "location of the configuration file to use"
 msgstr "Speicherort der zu verwendenden Konfigurationsdatei"
 
-#: ../../appendices/command_line.rst:24
+#: ../../appendices/command_line.rst:28
 msgid "enable debug-level logging"
 msgstr "Debug-Protokollierung aktivieren"
 
-#: ../../appendices/command_line.rst:28
+#: ../../appendices/command_line.rst:32
 msgid ""
 "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` "
 "for more information)"
@@ -58,35 +65,39 @@ msgstr ""
 "einen oder mehrere BEFEHLe beim Start ausführen (siehe :doc:`/usage/"
 "exec_commands` für weitere Informationen)"
 
-#: ../../appendices/command_line.rst:32
+#: ../../appendices/command_line.rst:36
 msgid "disable built-in media player"
 msgstr "integrierten Mediaplayer deaktivieren"
 
-#: ../../appendices/command_line.rst:36
+#: ../../appendices/command_line.rst:40
 msgid "do not restore window positions or sizes"
 msgstr "Fensterpositionen und -größen nicht wiederherstellen"
 
-#: ../../appendices/command_line.rst:40
+#: ../../appendices/command_line.rst:44
 msgid "do not load any plugins"
 msgstr "Plugins nicht laden"
 
-#: ../../appendices/command_line.rst:44
+#: ../../appendices/command_line.rst:48
+msgid "disable the crash dialog"
+msgstr ""
+
+#: ../../appendices/command_line.rst:52
 msgid "force Picard to create a new, stand-alone instance"
 msgstr "eine neue, eigenständige Instanz erzwingen"
 
-#: ../../appendices/command_line.rst:48
+#: ../../appendices/command_line.rst:56
 msgid "display the version information and exit"
 msgstr "Versionsinformationen anzeigen und beenden"
 
-#: ../../appendices/command_line.rst:52
+#: ../../appendices/command_line.rst:60
 msgid "display the long version information and exit"
 msgstr "Ausführliche Versionsinformationen anzeigen und beenden"
 
-#: ../../appendices/command_line.rst:56
+#: ../../appendices/command_line.rst:64
 msgid "one or more files, directories, URLs and MBIDs to load"
 msgstr "eine oder mehrere Dateien, Verzeichnisse, URLs und MBIDs zum Laden"
 
-#: ../../appendices/command_line.rst:60
+#: ../../appendices/command_line.rst:68
 msgid ""
 "Files and directories are specified including the path (either absolute or "
 "relative) to the file or directory, and may include drive specifiers. They "
@@ -96,16 +107,16 @@ msgid ""
 "\"release\", \"artist\" or \"track\" and ``<mbid>`` is the MusicBrainz "
 "Identifier of the entity."
 msgstr ""
-"Dateien und Verzeichnisse werden mit dem Pfad (entweder absolut oder relativ)"
-" zur Datei oder zum Verzeichnis angegeben und können "
+"Dateien und Verzeichnisse werden mit dem Pfad (entweder absolut oder "
+"relativ) zur Datei oder zum Verzeichnis angegeben und können "
 "Laufwerksspezifikationen enthalten. Pfade können auch mit dem Präfix "
-"``file://`` angegeben werden. URLs werden entweder mit dem Präfix ``http://``"
-" oder ``https://`` angegeben. MBIDs werden im Format "
-"``mbid://<entity_type>/<mbid>`` angegeben, wobei ``<entity_type>`` eines von "
+"``file://`` angegeben werden. URLs werden entweder mit dem Präfix ``http://"
+"`` oder ``https://`` angegeben. MBIDs werden im Format ``mbid://"
+"<entity_type>/<mbid>`` angegeben, wobei ``<entity_type>`` eines von "
 "„release“, „artist“ oder „track“ ist und ``<mbid>`` der MusicBrainz-"
 "Identifier des Objekts ist."
 
-#: ../../appendices/command_line.rst:66
+#: ../../appendices/command_line.rst:74
 msgid ""
 "If a specified item contains a space, it must be enclosed in quotes such as "
 "``\"/home/user/music/my song.mp3\"``."

--- a/_locale/fr/LC_MESSAGES/appendices/command_line.po
+++ b/_locale/fr/LC_MESSAGES/appendices/command_line.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 15:29-0700\n"
+"POT-Creation-Date: 2023-09-20 08:43-0600\n"
 "PO-Revision-Date: 2023-01-04 23:51+0000\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language-Team: French <https://translate.uploadedlobster.com/projects/picard-"
@@ -43,14 +43,21 @@ msgid "show a help message and exit"
 msgstr "affiche un message d'aide et quitte"
 
 #: ../../appendices/command_line.rst:20
+msgid ""
+"audit events passed as a comma-separated list, prefixes supported, use "
+"\"all\" to match any event. See the `Python Documentation <https://docs."
+"python.org/3/library/audit_events.html#audit-events>`_ for more information."
+msgstr ""
+
+#: ../../appendices/command_line.rst:24
 msgid "location of the configuration file to use"
 msgstr "emplacement du fichier de configuration à utiliser"
 
-#: ../../appendices/command_line.rst:24
+#: ../../appendices/command_line.rst:28
 msgid "enable debug-level logging"
 msgstr "active la journalisation au niveau du débogage"
 
-#: ../../appendices/command_line.rst:28
+#: ../../appendices/command_line.rst:32
 msgid ""
 "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` "
 "for more information)"
@@ -58,35 +65,39 @@ msgstr ""
 "exécuter une ou plusieurs COMMANDs au démarrage (voir :doc:`/usage/"
 "exec_commands` pour plus d'informations)"
 
-#: ../../appendices/command_line.rst:32
+#: ../../appendices/command_line.rst:36
 msgid "disable built-in media player"
 msgstr "désactiver le lecteur multimédia intégré"
 
-#: ../../appendices/command_line.rst:36
+#: ../../appendices/command_line.rst:40
 msgid "do not restore window positions or sizes"
 msgstr "ne restaure pas la position ou la taille des fenêtres"
 
-#: ../../appendices/command_line.rst:40
+#: ../../appendices/command_line.rst:44
 msgid "do not load any plugins"
 msgstr "ne chargent aucun plug-in"
 
-#: ../../appendices/command_line.rst:44
+#: ../../appendices/command_line.rst:48
+msgid "disable the crash dialog"
+msgstr ""
+
+#: ../../appendices/command_line.rst:52
 msgid "force Picard to create a new, stand-alone instance"
 msgstr "forcez Picard à créer une nouvelle instance autonome"
 
-#: ../../appendices/command_line.rst:48
+#: ../../appendices/command_line.rst:56
 msgid "display the version information and exit"
 msgstr "affiche les informations de version et quitte"
 
-#: ../../appendices/command_line.rst:52
+#: ../../appendices/command_line.rst:60
 msgid "display the long version information and exit"
 msgstr "affiche les informations de la version longue et quitte"
 
-#: ../../appendices/command_line.rst:56
+#: ../../appendices/command_line.rst:64
 msgid "one or more files, directories, URLs and MBIDs to load"
 msgstr "un ou plusieurs fichiers, répertoires, URLs et MBIDs à charger"
 
-#: ../../appendices/command_line.rst:60
+#: ../../appendices/command_line.rst:68
 msgid ""
 "Files and directories are specified including the path (either absolute or "
 "relative) to the file or directory, and may include drive specifiers. They "
@@ -105,7 +116,7 @@ msgstr ""
 "\"artist\" ou \"track\" et ``<mbid>`` est l'identifiant MusicBrainz de "
 "l'entité."
 
-#: ../../appendices/command_line.rst:66
+#: ../../appendices/command_line.rst:74
 msgid ""
 "If a specified item contains a space, it must be enclosed in quotes such as "
 "``\"/home/user/music/my song.mp3\"``."

--- a/_locale/gettext/appendices/command_line.pot
+++ b/_locale/gettext/appendices/command_line.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 15:29-0700\n"
+"POT-Creation-Date: 2023-09-20 08:43-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,49 +33,57 @@ msgid "show a help message and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:20
-msgid "location of the configuration file to use"
+msgid "audit events passed as a comma-separated list, prefixes supported, use \"all\" to match any event. See the `Python Documentation <https://docs.python.org/3/library/audit_events.html#audit-events>`_ for more information."
 msgstr ""
 
 #: ../../appendices/command_line.rst:24
-msgid "enable debug-level logging"
+msgid "location of the configuration file to use"
 msgstr ""
 
 #: ../../appendices/command_line.rst:28
-msgid "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` for more information)"
+msgid "enable debug-level logging"
 msgstr ""
 
 #: ../../appendices/command_line.rst:32
-msgid "disable built-in media player"
+msgid "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` for more information)"
 msgstr ""
 
 #: ../../appendices/command_line.rst:36
-msgid "do not restore window positions or sizes"
+msgid "disable built-in media player"
 msgstr ""
 
 #: ../../appendices/command_line.rst:40
-msgid "do not load any plugins"
+msgid "do not restore window positions or sizes"
 msgstr ""
 
 #: ../../appendices/command_line.rst:44
-msgid "force Picard to create a new, stand-alone instance"
+msgid "do not load any plugins"
 msgstr ""
 
 #: ../../appendices/command_line.rst:48
-msgid "display the version information and exit"
+msgid "disable the crash dialog"
 msgstr ""
 
 #: ../../appendices/command_line.rst:52
-msgid "display the long version information and exit"
+msgid "force Picard to create a new, stand-alone instance"
 msgstr ""
 
 #: ../../appendices/command_line.rst:56
-msgid "one or more files, directories, URLs and MBIDs to load"
+msgid "display the version information and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:60
+msgid "display the long version information and exit"
+msgstr ""
+
+#: ../../appendices/command_line.rst:64
+msgid "one or more files, directories, URLs and MBIDs to load"
+msgstr ""
+
+#: ../../appendices/command_line.rst:68
 msgid "Files and directories are specified including the path (either absolute or relative) to the file or directory, and may include drive specifiers. They can also be specified using the ``file://`` prefix. URLs are specified by using either the ``http://`` or ``https://`` prefix. MBIDs are specified in the format ``mbid://<entity_type>/<mbid>`` where ``<entity_type>`` is one of \"release\", \"artist\" or \"track\" and ``<mbid>`` is the MusicBrainz Identifier of the entity."
 msgstr ""
 
-#: ../../appendices/command_line.rst:66
+#: ../../appendices/command_line.rst:74
 msgid "If a specified item contains a space, it must be enclosed in quotes such as ``\"/home/user/music/my song.mp3\"``."
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/appendices/command_line.po
+++ b/_locale/nb_NO/LC_MESSAGES/appendices/command_line.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 15:29-0700\n"
+"POT-Creation-Date: 2023-09-20 08:43-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,48 +37,59 @@ msgid "show a help message and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:20
-msgid "location of the configuration file to use"
+msgid ""
+"audit events passed as a comma-separated list, prefixes supported, use "
+"\"all\" to match any event. See the `Python Documentation <https://docs."
+"python.org/3/library/audit_events.html#audit-events>`_ for more information."
 msgstr ""
 
 #: ../../appendices/command_line.rst:24
-msgid "enable debug-level logging"
+msgid "location of the configuration file to use"
 msgstr ""
 
 #: ../../appendices/command_line.rst:28
+msgid "enable debug-level logging"
+msgstr ""
+
+#: ../../appendices/command_line.rst:32
 msgid ""
 "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` "
 "for more information)"
 msgstr ""
 
-#: ../../appendices/command_line.rst:32
+#: ../../appendices/command_line.rst:36
 msgid "disable built-in media player"
 msgstr ""
 
-#: ../../appendices/command_line.rst:36
+#: ../../appendices/command_line.rst:40
 msgid "do not restore window positions or sizes"
 msgstr ""
 
-#: ../../appendices/command_line.rst:40
+#: ../../appendices/command_line.rst:44
 msgid "do not load any plugins"
 msgstr ""
 
-#: ../../appendices/command_line.rst:44
-msgid "force Picard to create a new, stand-alone instance"
-msgstr ""
-
 #: ../../appendices/command_line.rst:48
-msgid "display the version information and exit"
+msgid "disable the crash dialog"
 msgstr ""
 
 #: ../../appendices/command_line.rst:52
-msgid "display the long version information and exit"
+msgid "force Picard to create a new, stand-alone instance"
 msgstr ""
 
 #: ../../appendices/command_line.rst:56
-msgid "one or more files, directories, URLs and MBIDs to load"
+msgid "display the version information and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:60
+msgid "display the long version information and exit"
+msgstr ""
+
+#: ../../appendices/command_line.rst:64
+msgid "one or more files, directories, URLs and MBIDs to load"
+msgstr ""
+
+#: ../../appendices/command_line.rst:68
 msgid ""
 "Files and directories are specified including the path (either absolute or "
 "relative) to the file or directory, and may include drive specifiers. They "
@@ -89,7 +100,7 @@ msgid ""
 "Identifier of the entity."
 msgstr ""
 
-#: ../../appendices/command_line.rst:66
+#: ../../appendices/command_line.rst:74
 msgid ""
 "If a specified item contains a space, it must be enclosed in quotes such as "
 "``\"/home/user/music/my song.mp3\"``."

--- a/_locale/nl/LC_MESSAGES/appendices/command_line.po
+++ b/_locale/nl/LC_MESSAGES/appendices/command_line.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 15:29-0700\n"
+"POT-Creation-Date: 2023-09-20 08:43-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,48 +37,59 @@ msgid "show a help message and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:20
-msgid "location of the configuration file to use"
+msgid ""
+"audit events passed as a comma-separated list, prefixes supported, use "
+"\"all\" to match any event. See the `Python Documentation <https://docs."
+"python.org/3/library/audit_events.html#audit-events>`_ for more information."
 msgstr ""
 
 #: ../../appendices/command_line.rst:24
-msgid "enable debug-level logging"
+msgid "location of the configuration file to use"
 msgstr ""
 
 #: ../../appendices/command_line.rst:28
+msgid "enable debug-level logging"
+msgstr ""
+
+#: ../../appendices/command_line.rst:32
 msgid ""
 "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` "
 "for more information)"
 msgstr ""
 
-#: ../../appendices/command_line.rst:32
+#: ../../appendices/command_line.rst:36
 msgid "disable built-in media player"
 msgstr ""
 
-#: ../../appendices/command_line.rst:36
+#: ../../appendices/command_line.rst:40
 msgid "do not restore window positions or sizes"
 msgstr ""
 
-#: ../../appendices/command_line.rst:40
+#: ../../appendices/command_line.rst:44
 msgid "do not load any plugins"
 msgstr ""
 
-#: ../../appendices/command_line.rst:44
-msgid "force Picard to create a new, stand-alone instance"
-msgstr ""
-
 #: ../../appendices/command_line.rst:48
-msgid "display the version information and exit"
+msgid "disable the crash dialog"
 msgstr ""
 
 #: ../../appendices/command_line.rst:52
-msgid "display the long version information and exit"
+msgid "force Picard to create a new, stand-alone instance"
 msgstr ""
 
 #: ../../appendices/command_line.rst:56
-msgid "one or more files, directories, URLs and MBIDs to load"
+msgid "display the version information and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:60
+msgid "display the long version information and exit"
+msgstr ""
+
+#: ../../appendices/command_line.rst:64
+msgid "one or more files, directories, URLs and MBIDs to load"
+msgstr ""
+
+#: ../../appendices/command_line.rst:68
 msgid ""
 "Files and directories are specified including the path (either absolute or "
 "relative) to the file or directory, and may include drive specifiers. They "
@@ -89,7 +100,7 @@ msgid ""
 "Identifier of the entity."
 msgstr ""
 
-#: ../../appendices/command_line.rst:66
+#: ../../appendices/command_line.rst:74
 msgid ""
 "If a specified item contains a space, it must be enclosed in quotes such as "
 "``\"/home/user/music/my song.mp3\"``."

--- a/_locale/pt_BR/LC_MESSAGES/appendices/command_line.po
+++ b/_locale/pt_BR/LC_MESSAGES/appendices/command_line.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-03 15:29-0700\n"
+"POT-Creation-Date: 2023-09-20 08:43-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,48 +37,59 @@ msgid "show a help message and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:20
-msgid "location of the configuration file to use"
+msgid ""
+"audit events passed as a comma-separated list, prefixes supported, use "
+"\"all\" to match any event. See the `Python Documentation <https://docs."
+"python.org/3/library/audit_events.html#audit-events>`_ for more information."
 msgstr ""
 
 #: ../../appendices/command_line.rst:24
-msgid "enable debug-level logging"
+msgid "location of the configuration file to use"
 msgstr ""
 
 #: ../../appendices/command_line.rst:28
+msgid "enable debug-level logging"
+msgstr ""
+
+#: ../../appendices/command_line.rst:32
 msgid ""
 "execute one or more COMMANDs at start-up (see :doc:`/usage/exec_commands` "
 "for more information)"
 msgstr ""
 
-#: ../../appendices/command_line.rst:32
+#: ../../appendices/command_line.rst:36
 msgid "disable built-in media player"
 msgstr ""
 
-#: ../../appendices/command_line.rst:36
+#: ../../appendices/command_line.rst:40
 msgid "do not restore window positions or sizes"
 msgstr ""
 
-#: ../../appendices/command_line.rst:40
+#: ../../appendices/command_line.rst:44
 msgid "do not load any plugins"
 msgstr ""
 
-#: ../../appendices/command_line.rst:44
-msgid "force Picard to create a new, stand-alone instance"
-msgstr ""
-
 #: ../../appendices/command_line.rst:48
-msgid "display the version information and exit"
+msgid "disable the crash dialog"
 msgstr ""
 
 #: ../../appendices/command_line.rst:52
-msgid "display the long version information and exit"
+msgid "force Picard to create a new, stand-alone instance"
 msgstr ""
 
 #: ../../appendices/command_line.rst:56
-msgid "one or more files, directories, URLs and MBIDs to load"
+msgid "display the version information and exit"
 msgstr ""
 
 #: ../../appendices/command_line.rst:60
+msgid "display the long version information and exit"
+msgstr ""
+
+#: ../../appendices/command_line.rst:64
+msgid "one or more files, directories, URLs and MBIDs to load"
+msgstr ""
+
+#: ../../appendices/command_line.rst:68
 msgid ""
 "Files and directories are specified including the path (either absolute or "
 "relative) to the file or directory, and may include drive specifiers. They "
@@ -89,7 +100,7 @@ msgid ""
 "Identifier of the entity."
 msgstr ""
 
-#: ../../appendices/command_line.rst:66
+#: ../../appendices/command_line.rst:74
 msgid ""
 "If a specified item contains a space, it must be enclosed in quotes such as "
 "``\"/home/user/music/my song.mp3\"``."

--- a/appendices/command_line.rst
+++ b/appendices/command_line.rst
@@ -7,13 +7,17 @@ Picard can be started from the command line with the following arguments:
 
 .. code::
 
-   picard [-h] [-c CONFIG_FILE] [-d] [-N] [-P] [-s] [-v] [-V] [FILE_OR_URLs] [-e COMMANDs]
+   run_picard.py [-h] [-a AUDIT] [-c CONFIG_FILE] [-d] [-e COMMAND [COMMAND ...]] [-M] [-N] [-P] [--no-crash-dialog] [-s] [-v] [-V] [FILE_OR_URL ...]
 
 where the options are:
 
 .. option:: -h, --help
 
    show a help message and exit
+
+.. option:: -a AUDIT, --audit AUDIT
+
+   audit events passed as a comma-separated list, prefixes supported, use "all" to match any event. See the `Python Documentation <https://docs.python.org/3/library/audit_events.html#audit-events>`_ for more information.
 
 .. option:: -c CONFIG_FILE, --config-file CONFIG_FILE
 
@@ -38,6 +42,10 @@ where the options are:
 .. option:: -P, --no-plugins
 
    do not load any plugins
+
+.. option:: --no-crash-dialog
+
+   disable the crash dialog
 
 .. option:: -s, --stand-alone-instance
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

An addional command line option was added in https://github.com/metabrainz/picard/pull/2316

### Description of the Change

Add the information for the new `-a, --audit` command line option.  Also add the information for the `--no-crash-dialog` command line option that was added 2 years ago but was never documented.

### Additional Action Required

Once merged, the translation files will need to be updated.
