### PR TITLE
include details on getting "Debug" logs, normally and when crashes occur

### DIFF
--- a/_locale/de/LC_MESSAGES/troubleshooting/troubleshooting.po
+++ b/_locale/de/LC_MESSAGES/troubleshooting/troubleshooting.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-09-22 08:57-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -75,61 +75,180 @@ msgid ""
 "the community forums first."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:28
+#: ../../troubleshooting/troubleshooting.rst:26
 msgid ""
 "If you're still convinced you have found a new bug, open a `new ticket "
 "<https://tickets.musicbrainz.org/secure/CreateIssue.jspa?"
 "pid=10042&issuetype=1>`_ providing the following information:"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:31
+#: ../../troubleshooting/troubleshooting.rst:28
 msgid "Which version of Picard do you use? (\"Affects Version\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:32
+#: ../../troubleshooting/troubleshooting.rst:29
 msgid "Which operating system do you use? (\"Environment\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:33
+#: ../../troubleshooting/troubleshooting.rst:30
 msgid "What did you do when the bug occurred?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:34
-msgid "What actually happened and what did you expect to happen?"
+#: ../../troubleshooting/troubleshooting.rst:31
+msgid "What actually happened, and what did you expect to happen?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:35
+#: ../../troubleshooting/troubleshooting.rst:32
 msgid "If you're using plugins, which plugins do you have enabled?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:39
-msgid ":index:`Getting Logs <troubleshooting; logs>`"
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:41
+#: ../../troubleshooting/troubleshooting.rst:33
 msgid ""
-"For many bugs, it helps developers to have a log from Picard. You can see "
-"the log by going to :menuselection:`\"Help --> View Log\"`. You can also get "
-"a full debug log (better because it contains more detailed information) by "
-"starting Picard with :option:`-d` as a command-line argument. If you're "
-"using Windows, you can change your shortcut's Target (:menuselection:`right "
-"click shortcut --> Properties`) to::"
+"The **\"Debug\"** level log from the Picard session demonstrating the "
+"problem."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:48
-msgid ""
-"Pasting this log into your forum post or bug ticket can help developers and "
-"other users to resolve your issue more quickly."
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:52
+#: ../../troubleshooting/troubleshooting.rst:37
 msgid ""
 "Please remember to first remove any personal and confidential information "
 "like user id, passwords or authorization tokens before posting or submitting "
 "any log output."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:59
+#: ../../troubleshooting/troubleshooting.rst:41
+msgid ":index:`Getting a Debug Log <troubleshooting; get debug log>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:43
+msgid ""
+"For many bugs, it helps developers to have a debug log from Picard. You can "
+"see the log by going to :menuselection:`\"Help --> View Log\"`. You can also "
+"get a full debug log, which is better because it contains more detailed "
+"information. Pasting this log into your forum post or bug ticket can help "
+"developers and other users to resolve your issue more quickly. To retrieve "
+"the full debug log:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:45
+msgid "Start Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:46
+msgid "Open the log view with :menuselection:`\"Help --> View Log\"`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:47
+msgid "Change the log level :guilabel:`verbosity` to **Debug**."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:48
+msgid "Close the log viewer."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:49
+msgid "Close and restart Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:50
+msgid "Repeat the action that caused the problem being reported."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:51
+msgid ""
+"Open the log viewer and copy the output to paste into the forum post or bug "
+"ticket. Alternately, you can save the log to a file to attach to your bug "
+"report by using the :guilabel:`Save As...` button."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:52
+msgid "Close the log viewer, and close Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:56
+msgid ""
+":index:`Getting Logs in Case of Crashes <troubleshooting; getting log for "
+"crashes>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:58
+msgid ""
+"In some cases the problem will cause Picard to crash and not allow you to "
+"access the resulting log from the log viewer. You can still generate a log "
+"output to attach to your report by starting Picard with the ``--debug`` "
+"command line option from a command / terminal window and copying the log "
+"output information from the terminal. The steps to follow for each of the "
+"supported platforms are:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:61
+msgid "Windows Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:63
+msgid ""
+"First open a command window by clicking the search icon on the Windows "
+"Taskbar and enter \"cmd\". Then start Picard by entering the following in "
+"the command window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:69
+msgid ""
+"This will display all log entries in the command window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:73
+msgid ""
+"This method will only work with the installed version of Picard.  It will "
+"not work with the portable or Windows Store versions."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:77
+msgid "macOS Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:79
+msgid "First open a terminal window by doing one of the following:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:81
+msgid ""
+"Click the Launchpad icon in the Dock, type \"Terminal\" in the search field, "
+"then click :guilabel:`Terminal`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:83
+msgid ""
+"In the Finder, open the \"/Applications/Utilities\" folder, then double-"
+"click \"Terminal\"."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:85
+msgid ""
+"Assuming Picard was put into the system wide Applications folder when "
+"installed, it can then be started by entering the following in the terminal "
+"window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:91
+#: ../../troubleshooting/troubleshooting.rst:103
+msgid ""
+"This will display all log entries in the terminal window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:95
+msgid "Linux Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:97
+msgid ""
+"First open a Terminal window in your desktop environment, either from the "
+"Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then "
+"start Picard by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:110
 msgid ""
 "Specific situations: :doc:`does_not_start` / :doc:`no_coverart` / :doc:"
 "`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:"

--- a/_locale/fr/LC_MESSAGES/troubleshooting/troubleshooting.po
+++ b/_locale/fr/LC_MESSAGES/troubleshooting/troubleshooting.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-09-22 08:57-0600\n"
 "PO-Revision-Date: 2022-05-04 13:10-0600\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language-Team: \n"
@@ -95,7 +95,7 @@ msgstr ""
 "pas sûr ou ne souhaitez pas consulter les tickets existants, demandez "
 "d'abord sur les forums de la communauté."
 
-#: ../../troubleshooting/troubleshooting.rst:28
+#: ../../troubleshooting/troubleshooting.rst:26
 msgid ""
 "If you're still convinced you have found a new bug, open a `new ticket "
 "<https://tickets.musicbrainz.org/secure/CreateIssue.jspa?"
@@ -105,61 +105,38 @@ msgstr ""
 "`nouveau ticket <https://tickets.musicbrainz.org/secure/CreateIssue.jspa?"
 "pid=10042&issuetype=1>`_ fournissant les informations suivantes:"
 
-#: ../../troubleshooting/troubleshooting.rst:31
+#: ../../troubleshooting/troubleshooting.rst:28
 msgid "Which version of Picard do you use? (\"Affects Version\" in the form)"
 msgstr ""
 "Quelle version de Picard utilisez-vous? (\"Affecte la version\" dans le "
 "formulaire)"
 
-#: ../../troubleshooting/troubleshooting.rst:32
+#: ../../troubleshooting/troubleshooting.rst:29
 msgid "Which operating system do you use? (\"Environment\" in the form)"
 msgstr ""
 "Quel système d'exploitation utilisez-vous? (\"Environnement\" dans le "
 "formulaire)"
 
-#: ../../troubleshooting/troubleshooting.rst:33
+#: ../../troubleshooting/troubleshooting.rst:30
 msgid "What did you do when the bug occurred?"
 msgstr "Qu'avez-vous fait lorsque le bogue est survenu?"
 
-#: ../../troubleshooting/troubleshooting.rst:34
-msgid "What actually happened and what did you expect to happen?"
+#: ../../troubleshooting/troubleshooting.rst:31
+#, fuzzy
+msgid "What actually happened, and what did you expect to happen?"
 msgstr "Que s'est-il réellement passé et à quoi vous attendiez-vous?"
 
-#: ../../troubleshooting/troubleshooting.rst:35
+#: ../../troubleshooting/troubleshooting.rst:32
 msgid "If you're using plugins, which plugins do you have enabled?"
 msgstr "Si vous utilisez des plugins, quels plugins avez-vous activés?"
 
-#: ../../troubleshooting/troubleshooting.rst:39
-msgid ":index:`Getting Logs <troubleshooting; logs>`"
-msgstr ":index:`Récupération des journaux <dépannage; journaux>`"
-
-#: ../../troubleshooting/troubleshooting.rst:41
+#: ../../troubleshooting/troubleshooting.rst:33
 msgid ""
-"For many bugs, it helps developers to have a log from Picard. You can see "
-"the log by going to :menuselection:`\"Help --> View Log\"`. You can also get "
-"a full debug log (better because it contains more detailed information) by "
-"starting Picard with :option:`-d` as a command-line argument. If you're "
-"using Windows, you can change your shortcut's Target (:menuselection:`right "
-"click shortcut --> Properties`) to::"
+"The **\"Debug\"** level log from the Picard session demonstrating the "
+"problem."
 msgstr ""
-"Pour de nombreux bogues, cela aide les développeurs à avoir un journal de "
-"Picard. Vous pouvez voir le journal en allant dans :menuselection:`\"Aide --"
-"> Afficher le journal\"`. Vous pouvez également obtenir un journal de "
-"débogage complet (mieux car il contient des informations plus détaillées) en "
-"démarrant Picard avec :option:`-d` comme argument de ligne de commande. Si "
-"vous utilisez Windows, vous pouvez modifier la cible de votre raccourci (:"
-"menuselection:`raccourci clic droit --> Propriétés`) en::"
 
-#: ../../troubleshooting/troubleshooting.rst:48
-msgid ""
-"Pasting this log into your forum post or bug ticket can help developers and "
-"other users to resolve your issue more quickly."
-msgstr ""
-"Le fait de coller ce journal dans votre message de forum ou votre ticket de "
-"bogue peut aider les développeurs et les autres utilisateurs à résoudre "
-"votre problème plus rapidement."
-
-#: ../../troubleshooting/troubleshooting.rst:52
+#: ../../troubleshooting/troubleshooting.rst:37
 msgid ""
 "Please remember to first remove any personal and confidential information "
 "like user id, passwords or authorization tokens before posting or submitting "
@@ -170,7 +147,150 @@ msgstr ""
 "les jetons d'autorisation avant de publier ou de soumettre une sortie de "
 "journal."
 
-#: ../../troubleshooting/troubleshooting.rst:59
+#: ../../troubleshooting/troubleshooting.rst:41
+#, fuzzy
+msgid ":index:`Getting a Debug Log <troubleshooting; get debug log>`"
+msgstr ":index:`Récupération des journaux <dépannage; journaux>`"
+
+#: ../../troubleshooting/troubleshooting.rst:43
+#, fuzzy
+msgid ""
+"For many bugs, it helps developers to have a debug log from Picard. You can "
+"see the log by going to :menuselection:`\"Help --> View Log\"`. You can also "
+"get a full debug log, which is better because it contains more detailed "
+"information. Pasting this log into your forum post or bug ticket can help "
+"developers and other users to resolve your issue more quickly. To retrieve "
+"the full debug log:"
+msgstr ""
+"Pour de nombreux bogues, cela aide les développeurs à avoir un journal de "
+"Picard. Vous pouvez voir le journal en allant dans :menuselection:`\"Aide --"
+"> Afficher le journal\"`. Vous pouvez également obtenir un journal de "
+"débogage complet (mieux car il contient des informations plus détaillées) en "
+"démarrant Picard avec :option:`-d` comme argument de ligne de commande. Si "
+"vous utilisez Windows, vous pouvez modifier la cible de votre raccourci (:"
+"menuselection:`raccourci clic droit --> Propriétés`) en::"
+
+#: ../../troubleshooting/troubleshooting.rst:45
+msgid "Start Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:46
+msgid "Open the log view with :menuselection:`\"Help --> View Log\"`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:47
+msgid "Change the log level :guilabel:`verbosity` to **Debug**."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:48
+msgid "Close the log viewer."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:49
+msgid "Close and restart Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:50
+msgid "Repeat the action that caused the problem being reported."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:51
+msgid ""
+"Open the log viewer and copy the output to paste into the forum post or bug "
+"ticket. Alternately, you can save the log to a file to attach to your bug "
+"report by using the :guilabel:`Save As...` button."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:52
+msgid "Close the log viewer, and close Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:56
+#, fuzzy
+msgid ""
+":index:`Getting Logs in Case of Crashes <troubleshooting; getting log for "
+"crashes>`"
+msgstr ":index:`Récupération des journaux <dépannage; journaux>`"
+
+#: ../../troubleshooting/troubleshooting.rst:58
+msgid ""
+"In some cases the problem will cause Picard to crash and not allow you to "
+"access the resulting log from the log viewer. You can still generate a log "
+"output to attach to your report by starting Picard with the ``--debug`` "
+"command line option from a command / terminal window and copying the log "
+"output information from the terminal. The steps to follow for each of the "
+"supported platforms are:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:61
+msgid "Windows Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:63
+msgid ""
+"First open a command window by clicking the search icon on the Windows "
+"Taskbar and enter \"cmd\". Then start Picard by entering the following in "
+"the command window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:69
+msgid ""
+"This will display all log entries in the command window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:73
+msgid ""
+"This method will only work with the installed version of Picard.  It will "
+"not work with the portable or Windows Store versions."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:77
+msgid "macOS Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:79
+msgid "First open a terminal window by doing one of the following:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:81
+msgid ""
+"Click the Launchpad icon in the Dock, type \"Terminal\" in the search field, "
+"then click :guilabel:`Terminal`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:83
+msgid ""
+"In the Finder, open the \"/Applications/Utilities\" folder, then double-"
+"click \"Terminal\"."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:85
+msgid ""
+"Assuming Picard was put into the system wide Applications folder when "
+"installed, it can then be started by entering the following in the terminal "
+"window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:91
+#: ../../troubleshooting/troubleshooting.rst:103
+msgid ""
+"This will display all log entries in the terminal window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:95
+msgid "Linux Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:97
+msgid ""
+"First open a Terminal window in your desktop environment, either from the "
+"Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then "
+"start Picard by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:110
 msgid ""
 "Specific situations: :doc:`does_not_start` / :doc:`no_coverart` / :doc:"
 "`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:"
@@ -179,6 +299,14 @@ msgstr ""
 "Situations spécifiques: :doc:`does_not_start` / :doc:`no_coverart` / :doc:"
 "`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:"
 "`macos_startup_error`"
+
+#~ msgid ""
+#~ "Pasting this log into your forum post or bug ticket can help developers "
+#~ "and other users to resolve your issue more quickly."
+#~ msgstr ""
+#~ "Le fait de coller ce journal dans votre message de forum ou votre ticket "
+#~ "de bogue peut aider les développeurs et les autres utilisateurs à "
+#~ "résoudre votre problème plus rapidement."
 
 #~ msgid "General Troubleshooting"
 #~ msgstr "Dépannage général"

--- a/_locale/gettext/troubleshooting/troubleshooting.pot
+++ b/_locale/gettext/troubleshooting/troubleshooting.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MusicBrainz Picard v2.9alpha1\n"
+"Project-Id-Version: MusicBrainz Picard v2.9.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-09-22 08:57-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,46 +56,135 @@ msgstr ""
 msgid "If you think you have found a bug please check whether you are using the latest version of Picard and whether the bug has already been reported in the `bug tracker <https://tickets.musicbrainz.org/browse/PICARD>`_. If you're not sure or don't want to look through the existing tickets, ask on the community forums first."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:28
+#: ../../troubleshooting/troubleshooting.rst:26
 msgid "If you're still convinced you have found a new bug, open a `new ticket <https://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10042&issuetype=1>`_ providing the following information:"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:31
+#: ../../troubleshooting/troubleshooting.rst:28
 msgid "Which version of Picard do you use? (\"Affects Version\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:32
+#: ../../troubleshooting/troubleshooting.rst:29
 msgid "Which operating system do you use? (\"Environment\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:33
+#: ../../troubleshooting/troubleshooting.rst:30
 msgid "What did you do when the bug occurred?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:34
-msgid "What actually happened and what did you expect to happen?"
+#: ../../troubleshooting/troubleshooting.rst:31
+msgid "What actually happened, and what did you expect to happen?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:35
+#: ../../troubleshooting/troubleshooting.rst:32
 msgid "If you're using plugins, which plugins do you have enabled?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:39
-msgid ":index:`Getting Logs <troubleshooting; logs>`"
+#: ../../troubleshooting/troubleshooting.rst:33
+msgid "The **\"Debug\"** level log from the Picard session demonstrating the problem."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:41
-msgid "For many bugs, it helps developers to have a log from Picard. You can see the log by going to :menuselection:`\"Help --> View Log\"`. You can also get a full debug log (better because it contains more detailed information) by starting Picard with :option:`-d` as a command-line argument. If you're using Windows, you can change your shortcut's Target (:menuselection:`right click shortcut --> Properties`) to::"
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:48
-msgid "Pasting this log into your forum post or bug ticket can help developers and other users to resolve your issue more quickly."
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:52
+#: ../../troubleshooting/troubleshooting.rst:37
 msgid "Please remember to first remove any personal and confidential information like user id, passwords or authorization tokens before posting or submitting any log output."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:59
+#: ../../troubleshooting/troubleshooting.rst:41
+msgid ":index:`Getting a Debug Log <troubleshooting; get debug log>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:43
+msgid "For many bugs, it helps developers to have a debug log from Picard. You can see the log by going to :menuselection:`\"Help --> View Log\"`. You can also get a full debug log, which is better because it contains more detailed information. Pasting this log into your forum post or bug ticket can help developers and other users to resolve your issue more quickly. To retrieve the full debug log:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:45
+msgid "Start Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:46
+msgid "Open the log view with :menuselection:`\"Help --> View Log\"`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:47
+msgid "Change the log level :guilabel:`verbosity` to **Debug**."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:48
+msgid "Close the log viewer."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:49
+msgid "Close and restart Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:50
+msgid "Repeat the action that caused the problem being reported."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:51
+msgid "Open the log viewer and copy the output to paste into the forum post or bug ticket. Alternately, you can save the log to a file to attach to your bug report by using the :guilabel:`Save As...` button."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:52
+msgid "Close the log viewer, and close Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:56
+msgid ":index:`Getting Logs in Case of Crashes <troubleshooting; getting log for crashes>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:58
+msgid "In some cases the problem will cause Picard to crash and not allow you to access the resulting log from the log viewer. You can still generate a log output to attach to your report by starting Picard with the ``--debug`` command line option from a command / terminal window and copying the log output information from the terminal. The steps to follow for each of the supported platforms are:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:61
+msgid "Windows Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:63
+msgid "First open a command window by clicking the search icon on the Windows Taskbar and enter \"cmd\". Then start Picard by entering the following in the command window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:69
+msgid "This will display all log entries in the command window, and allow you to copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:73
+msgid "This method will only work with the installed version of Picard.  It will not work with the portable or Windows Store versions."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:77
+msgid "macOS Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:79
+msgid "First open a terminal window by doing one of the following:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:81
+msgid "Click the Launchpad icon in the Dock, type \"Terminal\" in the search field, then click :guilabel:`Terminal`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:83
+msgid "In the Finder, open the \"/Applications/Utilities\" folder, then double-click \"Terminal\"."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:85
+msgid "Assuming Picard was put into the system wide Applications folder when installed, it can then be started by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:91
+#: ../../troubleshooting/troubleshooting.rst:103
+msgid "This will display all log entries in the terminal window, and allow you to copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:95
+msgid "Linux Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:97
+msgid "First open a Terminal window in your desktop environment, either from the Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then start Picard by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:110
 msgid "Specific situations: :doc:`does_not_start` / :doc:`no_coverart` / :doc:`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:`macos_startup_error`"
 msgstr ""

--- a/_locale/nb_NO/LC_MESSAGES/troubleshooting/troubleshooting.po
+++ b/_locale/nb_NO/LC_MESSAGES/troubleshooting/troubleshooting.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-09-22 08:57-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -75,61 +75,180 @@ msgid ""
 "the community forums first."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:28
+#: ../../troubleshooting/troubleshooting.rst:26
 msgid ""
 "If you're still convinced you have found a new bug, open a `new ticket "
 "<https://tickets.musicbrainz.org/secure/CreateIssue.jspa?"
 "pid=10042&issuetype=1>`_ providing the following information:"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:31
+#: ../../troubleshooting/troubleshooting.rst:28
 msgid "Which version of Picard do you use? (\"Affects Version\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:32
+#: ../../troubleshooting/troubleshooting.rst:29
 msgid "Which operating system do you use? (\"Environment\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:33
+#: ../../troubleshooting/troubleshooting.rst:30
 msgid "What did you do when the bug occurred?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:34
-msgid "What actually happened and what did you expect to happen?"
+#: ../../troubleshooting/troubleshooting.rst:31
+msgid "What actually happened, and what did you expect to happen?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:35
+#: ../../troubleshooting/troubleshooting.rst:32
 msgid "If you're using plugins, which plugins do you have enabled?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:39
-msgid ":index:`Getting Logs <troubleshooting; logs>`"
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:41
+#: ../../troubleshooting/troubleshooting.rst:33
 msgid ""
-"For many bugs, it helps developers to have a log from Picard. You can see "
-"the log by going to :menuselection:`\"Help --> View Log\"`. You can also get "
-"a full debug log (better because it contains more detailed information) by "
-"starting Picard with :option:`-d` as a command-line argument. If you're "
-"using Windows, you can change your shortcut's Target (:menuselection:`right "
-"click shortcut --> Properties`) to::"
+"The **\"Debug\"** level log from the Picard session demonstrating the "
+"problem."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:48
-msgid ""
-"Pasting this log into your forum post or bug ticket can help developers and "
-"other users to resolve your issue more quickly."
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:52
+#: ../../troubleshooting/troubleshooting.rst:37
 msgid ""
 "Please remember to first remove any personal and confidential information "
 "like user id, passwords or authorization tokens before posting or submitting "
 "any log output."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:59
+#: ../../troubleshooting/troubleshooting.rst:41
+msgid ":index:`Getting a Debug Log <troubleshooting; get debug log>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:43
+msgid ""
+"For many bugs, it helps developers to have a debug log from Picard. You can "
+"see the log by going to :menuselection:`\"Help --> View Log\"`. You can also "
+"get a full debug log, which is better because it contains more detailed "
+"information. Pasting this log into your forum post or bug ticket can help "
+"developers and other users to resolve your issue more quickly. To retrieve "
+"the full debug log:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:45
+msgid "Start Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:46
+msgid "Open the log view with :menuselection:`\"Help --> View Log\"`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:47
+msgid "Change the log level :guilabel:`verbosity` to **Debug**."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:48
+msgid "Close the log viewer."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:49
+msgid "Close and restart Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:50
+msgid "Repeat the action that caused the problem being reported."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:51
+msgid ""
+"Open the log viewer and copy the output to paste into the forum post or bug "
+"ticket. Alternately, you can save the log to a file to attach to your bug "
+"report by using the :guilabel:`Save As...` button."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:52
+msgid "Close the log viewer, and close Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:56
+msgid ""
+":index:`Getting Logs in Case of Crashes <troubleshooting; getting log for "
+"crashes>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:58
+msgid ""
+"In some cases the problem will cause Picard to crash and not allow you to "
+"access the resulting log from the log viewer. You can still generate a log "
+"output to attach to your report by starting Picard with the ``--debug`` "
+"command line option from a command / terminal window and copying the log "
+"output information from the terminal. The steps to follow for each of the "
+"supported platforms are:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:61
+msgid "Windows Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:63
+msgid ""
+"First open a command window by clicking the search icon on the Windows "
+"Taskbar and enter \"cmd\". Then start Picard by entering the following in "
+"the command window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:69
+msgid ""
+"This will display all log entries in the command window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:73
+msgid ""
+"This method will only work with the installed version of Picard.  It will "
+"not work with the portable or Windows Store versions."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:77
+msgid "macOS Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:79
+msgid "First open a terminal window by doing one of the following:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:81
+msgid ""
+"Click the Launchpad icon in the Dock, type \"Terminal\" in the search field, "
+"then click :guilabel:`Terminal`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:83
+msgid ""
+"In the Finder, open the \"/Applications/Utilities\" folder, then double-"
+"click \"Terminal\"."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:85
+msgid ""
+"Assuming Picard was put into the system wide Applications folder when "
+"installed, it can then be started by entering the following in the terminal "
+"window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:91
+#: ../../troubleshooting/troubleshooting.rst:103
+msgid ""
+"This will display all log entries in the terminal window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:95
+msgid "Linux Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:97
+msgid ""
+"First open a Terminal window in your desktop environment, either from the "
+"Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then "
+"start Picard by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:110
 msgid ""
 "Specific situations: :doc:`does_not_start` / :doc:`no_coverart` / :doc:"
 "`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:"

--- a/_locale/nl/LC_MESSAGES/troubleshooting/troubleshooting.po
+++ b/_locale/nl/LC_MESSAGES/troubleshooting/troubleshooting.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.7.0b2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-09-22 08:57-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -75,61 +75,180 @@ msgid ""
 "the community forums first."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:28
+#: ../../troubleshooting/troubleshooting.rst:26
 msgid ""
 "If you're still convinced you have found a new bug, open a `new ticket "
 "<https://tickets.musicbrainz.org/secure/CreateIssue.jspa?"
 "pid=10042&issuetype=1>`_ providing the following information:"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:31
+#: ../../troubleshooting/troubleshooting.rst:28
 msgid "Which version of Picard do you use? (\"Affects Version\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:32
+#: ../../troubleshooting/troubleshooting.rst:29
 msgid "Which operating system do you use? (\"Environment\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:33
+#: ../../troubleshooting/troubleshooting.rst:30
 msgid "What did you do when the bug occurred?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:34
-msgid "What actually happened and what did you expect to happen?"
+#: ../../troubleshooting/troubleshooting.rst:31
+msgid "What actually happened, and what did you expect to happen?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:35
+#: ../../troubleshooting/troubleshooting.rst:32
 msgid "If you're using plugins, which plugins do you have enabled?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:39
-msgid ":index:`Getting Logs <troubleshooting; logs>`"
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:41
+#: ../../troubleshooting/troubleshooting.rst:33
 msgid ""
-"For many bugs, it helps developers to have a log from Picard. You can see "
-"the log by going to :menuselection:`\"Help --> View Log\"`. You can also get "
-"a full debug log (better because it contains more detailed information) by "
-"starting Picard with :option:`-d` as a command-line argument. If you're "
-"using Windows, you can change your shortcut's Target (:menuselection:`right "
-"click shortcut --> Properties`) to::"
+"The **\"Debug\"** level log from the Picard session demonstrating the "
+"problem."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:48
-msgid ""
-"Pasting this log into your forum post or bug ticket can help developers and "
-"other users to resolve your issue more quickly."
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:52
+#: ../../troubleshooting/troubleshooting.rst:37
 msgid ""
 "Please remember to first remove any personal and confidential information "
 "like user id, passwords or authorization tokens before posting or submitting "
 "any log output."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:59
+#: ../../troubleshooting/troubleshooting.rst:41
+msgid ":index:`Getting a Debug Log <troubleshooting; get debug log>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:43
+msgid ""
+"For many bugs, it helps developers to have a debug log from Picard. You can "
+"see the log by going to :menuselection:`\"Help --> View Log\"`. You can also "
+"get a full debug log, which is better because it contains more detailed "
+"information. Pasting this log into your forum post or bug ticket can help "
+"developers and other users to resolve your issue more quickly. To retrieve "
+"the full debug log:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:45
+msgid "Start Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:46
+msgid "Open the log view with :menuselection:`\"Help --> View Log\"`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:47
+msgid "Change the log level :guilabel:`verbosity` to **Debug**."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:48
+msgid "Close the log viewer."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:49
+msgid "Close and restart Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:50
+msgid "Repeat the action that caused the problem being reported."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:51
+msgid ""
+"Open the log viewer and copy the output to paste into the forum post or bug "
+"ticket. Alternately, you can save the log to a file to attach to your bug "
+"report by using the :guilabel:`Save As...` button."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:52
+msgid "Close the log viewer, and close Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:56
+msgid ""
+":index:`Getting Logs in Case of Crashes <troubleshooting; getting log for "
+"crashes>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:58
+msgid ""
+"In some cases the problem will cause Picard to crash and not allow you to "
+"access the resulting log from the log viewer. You can still generate a log "
+"output to attach to your report by starting Picard with the ``--debug`` "
+"command line option from a command / terminal window and copying the log "
+"output information from the terminal. The steps to follow for each of the "
+"supported platforms are:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:61
+msgid "Windows Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:63
+msgid ""
+"First open a command window by clicking the search icon on the Windows "
+"Taskbar and enter \"cmd\". Then start Picard by entering the following in "
+"the command window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:69
+msgid ""
+"This will display all log entries in the command window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:73
+msgid ""
+"This method will only work with the installed version of Picard.  It will "
+"not work with the portable or Windows Store versions."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:77
+msgid "macOS Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:79
+msgid "First open a terminal window by doing one of the following:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:81
+msgid ""
+"Click the Launchpad icon in the Dock, type \"Terminal\" in the search field, "
+"then click :guilabel:`Terminal`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:83
+msgid ""
+"In the Finder, open the \"/Applications/Utilities\" folder, then double-"
+"click \"Terminal\"."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:85
+msgid ""
+"Assuming Picard was put into the system wide Applications folder when "
+"installed, it can then be started by entering the following in the terminal "
+"window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:91
+#: ../../troubleshooting/troubleshooting.rst:103
+msgid ""
+"This will display all log entries in the terminal window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:95
+msgid "Linux Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:97
+msgid ""
+"First open a Terminal window in your desktop environment, either from the "
+"Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then "
+"start Picard by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:110
 msgid ""
 "Specific situations: :doc:`does_not_start` / :doc:`no_coverart` / :doc:"
 "`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:"

--- a/_locale/pt_BR/LC_MESSAGES/troubleshooting/troubleshooting.po
+++ b/_locale/pt_BR/LC_MESSAGES/troubleshooting/troubleshooting.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-14 08:09+0100\n"
+"POT-Creation-Date: 2023-09-22 08:57-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -75,61 +75,180 @@ msgid ""
 "the community forums first."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:28
+#: ../../troubleshooting/troubleshooting.rst:26
 msgid ""
 "If you're still convinced you have found a new bug, open a `new ticket "
 "<https://tickets.musicbrainz.org/secure/CreateIssue.jspa?"
 "pid=10042&issuetype=1>`_ providing the following information:"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:31
+#: ../../troubleshooting/troubleshooting.rst:28
 msgid "Which version of Picard do you use? (\"Affects Version\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:32
+#: ../../troubleshooting/troubleshooting.rst:29
 msgid "Which operating system do you use? (\"Environment\" in the form)"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:33
+#: ../../troubleshooting/troubleshooting.rst:30
 msgid "What did you do when the bug occurred?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:34
-msgid "What actually happened and what did you expect to happen?"
+#: ../../troubleshooting/troubleshooting.rst:31
+msgid "What actually happened, and what did you expect to happen?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:35
+#: ../../troubleshooting/troubleshooting.rst:32
 msgid "If you're using plugins, which plugins do you have enabled?"
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:39
-msgid ":index:`Getting Logs <troubleshooting; logs>`"
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:41
+#: ../../troubleshooting/troubleshooting.rst:33
 msgid ""
-"For many bugs, it helps developers to have a log from Picard. You can see "
-"the log by going to :menuselection:`\"Help --> View Log\"`. You can also get "
-"a full debug log (better because it contains more detailed information) by "
-"starting Picard with :option:`-d` as a command-line argument. If you're "
-"using Windows, you can change your shortcut's Target (:menuselection:`right "
-"click shortcut --> Properties`) to::"
+"The **\"Debug\"** level log from the Picard session demonstrating the "
+"problem."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:48
-msgid ""
-"Pasting this log into your forum post or bug ticket can help developers and "
-"other users to resolve your issue more quickly."
-msgstr ""
-
-#: ../../troubleshooting/troubleshooting.rst:52
+#: ../../troubleshooting/troubleshooting.rst:37
 msgid ""
 "Please remember to first remove any personal and confidential information "
 "like user id, passwords or authorization tokens before posting or submitting "
 "any log output."
 msgstr ""
 
-#: ../../troubleshooting/troubleshooting.rst:59
+#: ../../troubleshooting/troubleshooting.rst:41
+msgid ":index:`Getting a Debug Log <troubleshooting; get debug log>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:43
+msgid ""
+"For many bugs, it helps developers to have a debug log from Picard. You can "
+"see the log by going to :menuselection:`\"Help --> View Log\"`. You can also "
+"get a full debug log, which is better because it contains more detailed "
+"information. Pasting this log into your forum post or bug ticket can help "
+"developers and other users to resolve your issue more quickly. To retrieve "
+"the full debug log:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:45
+msgid "Start Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:46
+msgid "Open the log view with :menuselection:`\"Help --> View Log\"`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:47
+msgid "Change the log level :guilabel:`verbosity` to **Debug**."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:48
+msgid "Close the log viewer."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:49
+msgid "Close and restart Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:50
+msgid "Repeat the action that caused the problem being reported."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:51
+msgid ""
+"Open the log viewer and copy the output to paste into the forum post or bug "
+"ticket. Alternately, you can save the log to a file to attach to your bug "
+"report by using the :guilabel:`Save As...` button."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:52
+msgid "Close the log viewer, and close Picard."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:56
+msgid ""
+":index:`Getting Logs in Case of Crashes <troubleshooting; getting log for "
+"crashes>`"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:58
+msgid ""
+"In some cases the problem will cause Picard to crash and not allow you to "
+"access the resulting log from the log viewer. You can still generate a log "
+"output to attach to your report by starting Picard with the ``--debug`` "
+"command line option from a command / terminal window and copying the log "
+"output information from the terminal. The steps to follow for each of the "
+"supported platforms are:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:61
+msgid "Windows Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:63
+msgid ""
+"First open a command window by clicking the search icon on the Windows "
+"Taskbar and enter \"cmd\". Then start Picard by entering the following in "
+"the command window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:69
+msgid ""
+"This will display all log entries in the command window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:73
+msgid ""
+"This method will only work with the installed version of Picard.  It will "
+"not work with the portable or Windows Store versions."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:77
+msgid "macOS Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:79
+msgid "First open a terminal window by doing one of the following:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:81
+msgid ""
+"Click the Launchpad icon in the Dock, type \"Terminal\" in the search field, "
+"then click :guilabel:`Terminal`."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:83
+msgid ""
+"In the Finder, open the \"/Applications/Utilities\" folder, then double-"
+"click \"Terminal\"."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:85
+msgid ""
+"Assuming Picard was put into the system wide Applications folder when "
+"installed, it can then be started by entering the following in the terminal "
+"window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:91
+#: ../../troubleshooting/troubleshooting.rst:103
+msgid ""
+"This will display all log entries in the terminal window, and allow you to "
+"copy the information to the clipboard to paste into your report."
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:95
+msgid "Linux Systems"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:97
+msgid ""
+"First open a Terminal window in your desktop environment, either from the "
+"Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then "
+"start Picard by entering the following in the terminal window:"
+msgstr ""
+
+#: ../../troubleshooting/troubleshooting.rst:110
 msgid ""
 "Specific situations: :doc:`does_not_start` / :doc:`no_coverart` / :doc:"
 "`missing_tags` / :doc:`not_saving` / :doc:`stopped_working` / :doc:"

--- a/troubleshooting/troubleshooting.rst
+++ b/troubleshooting/troubleshooting.rst
@@ -40,7 +40,7 @@ If you're still convinced you have found a new bug, open a `new ticket <https://
 :index:`Getting a Debug Log <troubleshooting; get debug log>`
 -------------------------------------------------------------
 
-For many bugs, it helps developers to have a log from Picard. You can see the log by going to :menuselection:`"Help --> View Log"`. You can also get a full debug log, which is better because it contains more detailed information. Pasting this log into your forum post or bug ticket can help developers and other users to resolve your issue more quickly. To retrieve the full debug log:
+For many bugs, it helps developers to have a debug log from Picard. You can see the log by going to :menuselection:`"Help --> View Log"`. You can also get a full debug log, which is better because it contains more detailed information. Pasting this log into your forum post or bug ticket can help developers and other users to resolve your issue more quickly. To retrieve the full debug log:
 
 1. Start Picard.
 2. Open the log view with :menuselection:`"Help --> View Log"`.
@@ -52,10 +52,10 @@ For many bugs, it helps developers to have a log from Picard. You can see the lo
 8. Close the log viewer, and close Picard.
 
 
-:index:`Getting Logs in Case of Crashes <troubleshooting; getting log for chashes>`
+:index:`Getting Logs in Case of Crashes <troubleshooting; getting log for crashes>`
 -----------------------------------------------------------------------------------
 
-In some cases the problem will cause Picard to crash and not allow you to access the resulting log from the log viewer. You can still generate a log output to attach to your report by starting Picard with the ``-d`` command line option from a command / terminal window and copying the information output to the terminal. The steps to follow for each of the supported platforms are:
+In some cases the problem will cause Picard to crash and not allow you to access the resulting log from the log viewer. You can still generate a log output to attach to your report by starting Picard with the ``--debug`` command line option from a command / terminal window and copying the log output information from the terminal. The steps to follow for each of the supported platforms are:
 
 Windows Systems
 +++++++++++++++
@@ -64,13 +64,13 @@ First open a command window by clicking the search icon on the Windows Taskbar a
 
 .. code::
 
-   "C:\Program Files\MusicBrainz Picard\picard.exe" -d
+   "C:\Program Files\MusicBrainz Picard\picard.exe" --debug
 
-This will display all log information in the command window, and allow you to copy the information to the clipboard to paste into your report.
+This will display all log entries in the command window, and allow you to copy the information to the clipboard to paste into your report.
 
 .. note::
 
-   This method will only work with the installed version of Picard.  It will not work with the portable version.
+   This method will only work with the installed version of Picard.  It will not work with the portable or Windows Store versions.
 
 
 macOS Systems
@@ -88,19 +88,19 @@ Assuming Picard was put into the system wide Applications folder when installed,
 
    "/Applications/MusicBrainz Picard.app/Contents/MacOS/picard-run" --debug
 
-This will display all log information in the terminal window, and allow you to copy the information to the clipboard to paste into your report.
+This will display all log entries in the terminal window, and allow you to copy the information to the clipboard to paste into your report.
 
 
 Linux Systems
 +++++++++++++
 
-First open a Terminal window. Then start Picard by entering the following in the terminal window:
+First open a Terminal window in your desktop environment, either from the Applications menu or by pressing :kbd:`Ctrl+Alt+T` on most systems. Then start Picard by entering the following in the terminal window:
 
 .. code::
 
-   picard -d
+   picard --debug
 
-This will display all log information in the terminal window, and allow you to copy the information to the clipboard to paste into your report.
+This will display all log entries in the terminal window, and allow you to copy the information to the clipboard to paste into your report.
 
 
 .. only:: html and not epub

--- a/troubleshooting/troubleshooting.rst
+++ b/troubleshooting/troubleshooting.rst
@@ -21,36 +21,87 @@ If you have problems using Picard, please first check the following resources:
 :index:`Reporting a Bug <troubleshooting; reporting a bug>`
 ------------------------------------------------------------
 
-If you think you have found a bug please check whether you are using the latest version of Picard and whether the
-bug has already been reported in the `bug tracker <https://tickets.musicbrainz.org/browse/PICARD>`_. If you're not
-sure or don't want to look through the existing tickets, ask on the community forums first.
+If you think you have found a bug please check whether you are using the latest version of Picard and whether the bug has already been reported in the `bug tracker <https://tickets.musicbrainz.org/browse/PICARD>`_. If you're not sure or don't want to look through the existing tickets, ask on the community forums first.
 
-If you're still convinced you have found a new bug, open a `new ticket
-<https://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10042&issuetype=1>`_ providing the following information:
+If you're still convinced you have found a new bug, open a `new ticket <https://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10042&issuetype=1>`_ providing the following information:
 
 * Which version of Picard do you use? ("Affects Version" in the form)
 * Which operating system do you use? ("Environment" in the form)
 * What did you do when the bug occurred?
-* What actually happened and what did you expect to happen?
+* What actually happened, and what did you expect to happen?
 * If you're using plugins, which plugins do you have enabled?
-
-
-:index:`Getting Logs <troubleshooting; logs>`
-----------------------------------------------
-
-For many bugs, it helps developers to have a log from Picard. You can see the log by going to :menuselection:`"Help --> View Log"`.
-You can also get a full debug log (better because it contains more detailed information) by starting Picard with :option:`-d` as a
-command-line argument. If you're using Windows, you can change your shortcut's Target (:menuselection:`right click shortcut -->
-Properties`) to::
-
-    "C:\Program Files\MusicBrainz Picard\picard.exe" -d
-
-Pasting this log into your forum post or bug ticket can help developers and other users to resolve your issue more quickly.
+* The **"Debug"** level log from the Picard session demonstrating the problem.
 
 .. warning::
 
-   Please remember to first remove any personal and confidential information like user id, passwords or authorization tokens
-   before posting or submitting any log output.
+   Please remember to first remove any personal and confidential information like user id, passwords or authorization tokens before posting or submitting any log output.
+
+
+:index:`Getting a Debug Log <troubleshooting; get debug log>`
+-------------------------------------------------------------
+
+For many bugs, it helps developers to have a log from Picard. You can see the log by going to :menuselection:`"Help --> View Log"`. You can also get a full debug log, which is better because it contains more detailed information. Pasting this log into your forum post or bug ticket can help developers and other users to resolve your issue more quickly. To retrieve the full debug log:
+
+1. Start Picard.
+2. Open the log view with :menuselection:`"Help --> View Log"`.
+3. Change the log level :guilabel:`verbosity` to **Debug**.
+4. Close the log viewer.
+5. Close and restart Picard.
+6. Repeat the action that caused the problem being reported.
+7. Open the log viewer and copy the output to paste into the forum post or bug ticket. Alternately, you can save the log to a file to attach to your bug report by using the :guilabel:`Save As...` button.
+8. Close the log viewer, and close Picard.
+
+
+:index:`Getting Logs in Case of Crashes <troubleshooting; getting log for chashes>`
+-----------------------------------------------------------------------------------
+
+In some cases the problem will cause Picard to crash and not allow you to access the resulting log from the log viewer. You can still generate a log output to attach to your report by starting Picard with the ``-d`` command line option from a command / terminal window and copying the information output to the terminal. The steps to follow for each of the supported platforms are:
+
+Windows Systems
++++++++++++++++
+
+First open a command window by clicking the search icon on the Windows Taskbar and enter "cmd". Then start Picard by entering the following in the command window:
+
+.. code::
+
+   "C:\Program Files\MusicBrainz Picard\picard.exe" -d
+
+This will display all log information in the command window, and allow you to copy the information to the clipboard to paste into your report.
+
+.. note::
+
+   This method will only work with the installed version of Picard.  It will not work with the portable version.
+
+
+macOS Systems
++++++++++++++
+
+First open a terminal window by doing one of the following:
+
+- Click the Launchpad icon in the Dock, type "Terminal" in the search field, then click :guilabel:`Terminal`.
+
+- In the Finder, open the "/Applications/Utilities" folder, then double-click "Terminal".
+
+Assuming Picard was put into the system wide Applications folder when installed, it can then be started by entering the following in the terminal window:
+
+.. code::
+
+   "/Applications/MusicBrainz Picard.app/Contents/MacOS/picard-run" --debug
+
+This will display all log information in the terminal window, and allow you to copy the information to the clipboard to paste into your report.
+
+
+Linux Systems
++++++++++++++
+
+First open a Terminal window. Then start Picard by entering the following in the terminal window:
+
+.. code::
+
+   picard -d
+
+This will display all log information in the terminal window, and allow you to copy the information to the clipboard to paste into your report.
+
 
 .. only:: html and not epub
 


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [x] Addition
- [x] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Improve instructions for obtaining debug log output under various conditions as suggested by @phw  in https://github.com/metabrainz/picard-docs/pull/211

### Description of the Change

Update the Troubleshooting section to include details on getting "Debug" logs, normally and when crashes occur.

### Additional Action Required

Update translation files
