### PR TITLE
Move recording variables to Advanced Variables section

### DIFF
--- a/variables/variables_advanced.rst
+++ b/variables/variables_advanced.rst
@@ -24,11 +24,31 @@ If you enable tagging with :doc:`Use track relationships </config/options_metada
 
 **_recordingcomment**
 
-    Recording disambiguation comment. (*since Picard 0.15*)
+   The disambiguation comment for the recording associated with a track. (*since Picard 0.15*)
 
 **_recordingtitle**
 
     Recording title - normally the same as the Track title, but can be different.
+
+**_recording_firstreleasedate**
+
+   The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)
+
+**_recording_series**
+
+   The series title(s) associated with the recording (multi-value). (*since Picard 2.9*)
+
+**_recording_seriesid**
+
+   The series MBID(s) associated with the recording (multi-value). (*since Picard 2.9*)
+
+**_recording_seriescomment**
+
+   The series disambiguation comment(s) associated with the recording (multi-value). (*since Picard 2.9*)
+
+**_recording_seriesnumber**
+
+   The series number(s) associated with the recording (multi-value). (*since Picard 2.9*)
 
 **_workcomment**
 

--- a/variables/variables_basic.rst
+++ b/variables/variables_basic.rst
@@ -66,30 +66,6 @@ These variables are populated from MusicBrainz data for most releases, without a
 
     Rating 0-5 by MusicBrainz users.
 
-**_recording_comment**
-
-   The disambiguation comment for the recording associated with a track.
-
-**_recording_firstreleasedate**
-
-   The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)
-
-**_recording_series**
-
-   The series title(s) associated with the recording (multi-value). (*since Picard 2.9*)
-
-**_recording_seriesid**
-
-   The series MBID(s) associated with the recording (multi-value). (*since Picard 2.9*)
-
-**_recording_seriescomment**
-
-   The series disambiguation comment(s) associated with the recording (multi-value). (*since Picard 2.9*)
-
-**_recording_seriesnumber**
-
-   The series number(s) associated with the recording (multi-value). (*since Picard 2.9*)
-
 **_releaseannotation**
 
    The annotation comment for the release. (*since Picard 2.6*)


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The recording variables were shown in the Basic Variables section, when they actually require that the recording level relationships option be enabled.

### Description of the Change

Move the recording variables to the Advanced Variables section.

### Additional Action Required

Update translation files.
