### PR TITLE
fixed quick start guide link

### DIFF
--- a/troubleshooting/troubleshooting.rst
+++ b/troubleshooting/troubleshooting.rst
@@ -9,7 +9,7 @@ Getting Help
 If you have problems using Picard, please first check the following resources:
 
 * For general usage information see the :doc:`/usage/using` documentation and the `illustrated quick start guide
-  <https://picard.musicbrainz.org/docs/guide/>`_.
+  <https://picard.musicbrainz.org/quick-start/>`_.
 * Read the :doc:`FAQ section </faq/faq>` for common questions and problems.
 * Consult the `community forums <https://community.metabrainz.org/c/picard>`_.
 * Check the `download page <https://picard.musicbrainz.org/downloads/>`_ for a newer version of Picard which might


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change
There is a [broken link in documentation.](https://tickets.metabrainz.org/browse/PICARD-2808)
The link pointing to the quick start guide in the documentation was broken, therefore it needed to be corrected.

### Description of the Change

Fixed the url pointing to quick start guide and set it to : https://picard.musicbrainz.org/quick-start/

### Additional Action Required

No additional action required.
