### PR TITLE
Extend docs to include macOs options access

### DIFF
--- a/config/configuration.rst
+++ b/config/configuration.rst
@@ -66,9 +66,10 @@ actions that Picard can perform when saving selected music files:
 :index:`Option Settings <see: option settings; configuration>`
 ---------------------------------------------------------------
 
-The option settings are found under the :menuselection:`"Options --> Options..."` item on the menu bar.  This will open
-a new window with the option groups listed in a tree format on the left hand side, and the individual
-settings on the right hand side.  This is where the majority of Picard's customization is performed.
+The option settings are found under the :menuselection:`"Options --> Options..."` item on the menu bar. Whereas in the MacOs ,the option
+settings are found under the :menuselection:`"Python --> Preferences ..."` item on the menu bar . This will open a new window with 
+the option groups listed in a tree format on the left hand side, and the individual settings on the right hand side.This is where 
+the majority of Picard's customization is performed.
 
 .. only:: html
 

--- a/config/configuration.rst
+++ b/config/configuration.rst
@@ -71,7 +71,7 @@ with :menuselection:`"MusicBrainz Picard --> Preferences..."`. This will open a 
 format on the left hand side, and the individual settings on the right hand side. This is where the majority of Picard's 
 customization is performed.
 
-..  note:: 
+.. note:: 
    When running your code from the source in a macOS environment, you can access the option settings by navigating to the 
    :menuselection:`"Python --> Preferences..."` option in the menu bar. This allows you to configure and customize various settings 
    for your development environment.

--- a/config/configuration.rst
+++ b/config/configuration.rst
@@ -66,10 +66,14 @@ actions that Picard can perform when saving selected music files:
 :index:`Option Settings <see: option settings; configuration>`
 ---------------------------------------------------------------
 
-The option settings are found under the :menuselection:`"Options --> Options..."` item on the menu bar. Whereas in the MacOs ,the option
-settings are found under the :menuselection:`"Python --> Preferences ..."` item on the menu bar . This will open a new window with 
-the option groups listed in a tree format on the left hand side, and the individual settings on the right hand side.This is where 
+The option settings are found under the :menuselection:`"Options --> Options..."` item on the menu bar. This will open a new window with 
+the option groups listed in a tree format on the left hand side, and the individual settings on the right hand side. This is where 
 the majority of Picard's customization is performed.
+
+..  note:: 
+   When running your code from the source in a macOS environment, you can access the option settings by navigating to the 
+   :menuselection:`"Python --> Preferences..."` option in the menu bar. This allows you to configure and customize various settings 
+   for your development environment.
 
 .. only:: html
 

--- a/config/configuration.rst
+++ b/config/configuration.rst
@@ -66,9 +66,10 @@ actions that Picard can perform when saving selected music files:
 :index:`Option Settings <see: option settings; configuration>`
 ---------------------------------------------------------------
 
-The option settings are found under the :menuselection:`"Options --> Options..."` item on the menu bar. This will open a new window with 
-the option groups listed in a tree format on the left hand side, and the individual settings on the right hand side. This is where 
-the majority of Picard's customization is performed.
+The option settings are found under the :menuselection:`"Options --> Options..."` item on the menu bar. On macOS they can be accessed 
+with :menuselection:`"MusicBrainz Picard --> Preferences..."`. This will open a new window with the option groups listed in a tree 
+format on the left hand side, and the individual settings on the right hand side. This is where the majority of Picard's 
+customization is performed.
 
 ..  note:: 
    When running your code from the source in a macOS environment, you can access the option settings by navigating to the 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

I was trying to address was how to access the plugins for Picard , which was discussed in the thread here : https://community.metabrainz.org/t/how-to-run-plugins-on-picard-as-a-developer/674175 .I think that clearly mentioning the access to plugins or options menu to MacOs users would be more intuitive and useful .

Jira Ticket _(optional)_ - [PICARD-2818](https://tickets.metabrainz.org/browse/PICARD-2818)

### Description of the Change

I essentially added the path of action which would lead to the user reaching the plugins selection via the options menu in a MacOs environment , extending the guide to the windows based systems . adjoining with the pr are screenshots demonstrating the working of the pathway updated in the pr . 

<img width="416" alt="Screenshot 2024-01-12 at 2 15 11 AM" src="https://github.com/metabrainz/picard-docs/assets/94298612/5b8393f7-7819-483f-a295-ee633b0a91bb">

img 1 . Python --> Preferences 

<img width="806" alt="Screenshot 2024-01-12 at 2 15 54 AM" src="https://github.com/metabrainz/picard-docs/assets/94298612/59a91eaf-487b-492c-8c04-46c4ac4f8431">

img 2. plugins selection 

### Additional Action Required

No Additional Action Required .
