### PR TITLE
Add mapping for synced lyrics tag

### DIFF
--- a/about_picard/acknowledgements.rst
+++ b/about_picard/acknowledgements.rst
@@ -14,6 +14,7 @@ Contributors include (in alphabetic surname order):
 - Pavan Chander
 - Ronan Desplanques
 - Gabriel Ferreira
+- Giorgio Fontanive
 - Rahul Kumar Gupta
 - Wieland Hoffmann
 - InvisibleMan78

--- a/appendices/tag_mapping.rst
+++ b/appendices/tag_mapping.rst
@@ -550,6 +550,21 @@ Lyrics :sup:`[4]`
    "RIFF INFO", "n/a"
 
 
+Synced Lyrics
+--------------
+.. csv-table::
+   :width: 100%
+   :widths: 37 100
+
+   "Internal Name", "``syncedlyrics:language:description``"
+   "ID3v2", "``SYLT:description``"
+   "Vorbis", "n/a"
+   "APEv2", "n/a"
+   "iTunes MP4", "n/a"
+   "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
+
+
 `Media <https://musicbrainz.org/doc/Release_Format>`_
 ------------------------------------------------------
 .. csv-table::

--- a/tag_mapping.py
+++ b/tag_mapping.py
@@ -473,6 +473,17 @@ TAG_MAP = [
     },
 
     {
+        "tag_name": "Synced Lyrics",
+        "picard_name": "``syncedlyrics:language:description``",
+        "id3v2": "``SYLT:description``",
+        "vorbis": "n/a",
+        "apev2": "n/a",
+        "itunes": "n/a",
+        "wmp": "n/a",
+        "riff": "n/a",
+    },
+
+    {
         "tag_name": "`Media <https://musicbrainz.org/doc/Release_Format>`_",
         "picard_name": "``media``",
         "id3v2": "``TMED``",

--- a/variables/tags_basic.rst
+++ b/variables/tags_basic.rst
@@ -244,7 +244,7 @@ These tags are not able to be populated by stock Picard, however they may be use
 
 **syncedlyrics**
 
-    The synced lyrics for the track.
+    The synchronized lyrics for the track.
 
 **musicip_fingerprint**
 

--- a/variables/tags_basic.rst
+++ b/variables/tags_basic.rst
@@ -242,6 +242,10 @@ These tags are not able to be populated by stock Picard, however they may be use
 
    The lyrics for the track.
 
+**syncedlyrics**
+
+    The synced lyrics for the track.
+
 **musicip_fingerprint**
 
    The MusicIP Fingerprint for the track.


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

This adds the synced lyrics tag mapping. 
So far only id3 is supported.
