### PR TITLE
Fix typo in $dateformat() function examples

### DIFF
--- a/functions/func_dateformat.rst
+++ b/functions/func_dateformat.rst
@@ -49,7 +49,7 @@ The following statements will return the values indicated:
    $dateformat(2021-7-21)                ==>  "2021-07-21"
    $dateformat(2021-7-21,\%B \%d\, \%Y)  ==>  "July 21, 2021"
 
-   $dateformat(2021-07-21,,myd)          ==>  "2021-07-21"
+   $dateformat(2021-07-21,,ymd)          ==>  "2021-07-21"
    $dateformat(2021-07-21,,dmy)          ==>  ""
    $dateformat(2021-07-21,,mdy)          ==>  ""
    $dateformat(2021-July-21)             ==>  ""


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

One of the examples in the `$dateformat()` function had an incorrect argument.

### Description of the Change

Change incorrect argument `myd` to `ymd`.

### Additional Action Required

Update translation files.
