### PR TITLE
PICARD-3054: Add new `_albumartists_countries` and `_artists_countries` variables

### DIFF
--- a/variables/variables_basic.rst
+++ b/variables/variables_basic.rst
@@ -23,9 +23,17 @@ Some variables provide the :index:`MusicBrainz Identifier (MBID) <identifier; mu
 
    A multi-value variable containing the names of the album's artists. These could be either "standardized" or "as credited" depending on whether the "Use standardized artist names" metadata option is enabled. (*since Picard 1.3*)
 
+**_albumartists_countries**
+
+   A multi-value variable containing the country codes for all of the credited album artists, in the same order as the artists. Duplicate country codes will be shown if there are more than one artist from the same country. If a country code is not provided by the webservice the code "XX" will be used to indicate an unknown country. For example, if the first credited artist is from Great Britain and there are two other credited artists from Canada, the value would be "GB; CA; CA".
+
 **_albumartists_sort**
 
    A multi-value variable containing the sort names of the album's artists. (*since Picard 1.3*)
+
+**_artists_countries**
+
+   A multi-value variable containing the country codes for all of the credited track artists, in the same order as the artists. Duplicate country codes will be shown if there are more than one artist from the same country. If a country code is not provided by the webservice the code "XX" will be used to indicate an unknown country. For example, if the first credited artist is from Great Britain and there are two other credited artists from Canada, the value would be "GB; CA; CA".
 
 **_artists_sort**
 


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

New variables are being added in https://github.com/metabrainz/picard/pull/2627

### Description of the Change

Add the new variables to the documentation.

### Additional Action Required

None.
