### PR TITLE
PICARD-3068: Document group parameter for $rsearch (PICARD-3072)

### DIFF
--- a/functions/func_rsearch.rst
+++ b/functions/func_rsearch.rst
@@ -5,7 +5,7 @@
 $rsearch
 ========
 
-| Usage: **$rsearch(text,pattern)**
+| Usage: **$rsearch(text,pattern[,group])**
 | Category: text
 
 **Description:**
@@ -21,6 +21,13 @@ If more than one marked subexpression is defined and not all are matched, an emp
 be returned.  If no subexpression is specified, then the pattern captured by the whole search
 expression will be returned.
 
+If the optional ``group`` parameter is not provided or is empty, return the first
+capture group which matched something (including the empty string) or the
+entire match.
+
+If ``group`` is an integer, return the capture group in the position matching this integer.
+Otherwise, return the capture group named ``group``, sans surrounding whitespace.
+
 .. note::
 
    When entering regular expressions into Picard scripts you have to escape a backslash "\\",
@@ -28,6 +35,10 @@ expression will be returned.
    Picard to not interpret them as part of the script command.  This is done by inserting
    a backslash before the character to be escaped.  For example, the regular expression
    ``^\s*([0-9,\.]*)$`` would have to be entered as ``^\\s*\([0-9\,\\.]*\)\$``.
+
+.. note::
+
+   The ``group`` argument was added in Picard v2.14.
 
 **Example:**
 
@@ -44,3 +55,5 @@ The following statements will return the values indicated:
     $rsearch(test,\(e\).*\(s\))                      ==>  "e"
     $rsearch(test,\(e\).*x)                          ==>  ""
     $rsearch(test,\(e\).*\(x\))                      ==>  ""
+    $rsearch(disc: 3,\(\\w+\): \(\\d+\),1)           ==>  "disc"
+    $rsearch(disc: 3,\(\\w+\): \(\\d+\),2)           ==>  "3"


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

In PICARD-3072 / PICARD-3065 a new group parameter got added to the `$rsearch` function. This was backported to the 2.x branch and will be part of the 2.14 release.

Doc-Ticket: PICARD-3068

### Description of the Change

Document the `$group` parameter. Compare also https://github.com/metabrainz/picard/commit/16b943df155b30e18ab71cb8fae6a312cb3a991d