### PR TITLE
Docs: Expand cover art context menu documentation

### DIFF
--- a/usage/coverart.rst
+++ b/usage/coverart.rst
@@ -24,7 +24,17 @@ Once the release information has been downloaded, selecting an album or track in
 
 By right clicking on the image and selecting :menuselection:`"Choose local file…"` from the menu, you can choose a local file as the cover art.
 
-The menu also provides additional options including :menuselection:`"Show more details"`, :menuselection:`"Keep original cover art"`, and options for the way that images dropped onto the selection are processed.
+The context menu also provides several additional options:
+
+* :menuselection:`Show more details…` — Opens the cover art information window showing detailed information about the selected artwork.
+* :menuselection:`Keep original cover art` — Restores the original artwork if new cover art has been downloaded or added.
+* :menuselection:`Choose local file…` — Allows selecting one or more image files from the local filesystem to use as cover art.
+* :menuselection:`Add from URL…` — Downloads an image from a specified URL and adds it as cover art.
+
+The menu also includes options controlling how newly added images are handled:
+
+* :menuselection:`Replace front cover art` — Replaces the existing front cover image.
+* :menuselection:`Append front cover art` — Adds the new image while keeping the existing artwork.
 
 Selecting :menuselection:`"Show more details"` will bring up a new window as:
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change
The current “Setting the Cover Art” documentation briefly mentions the context menu but does not describe the available options in detail.
This can make it difficult for users to understand what actions are available when right-clicking the cover art image.

This change improves the documentation by explicitly listing the context menu options available in the cover art panel.


### Description of the Change
This update expands the documentation in usage/coverart.rst to describe the context menu options available when right-clicking on the cover art image.

The following actions are now documented:
	•	Show more details…
	•	Keep original cover art
	•	Choose local file…
	•	Add from URL…
	•	Replace front cover art
	•	Append front cover art

The structure and formatting follow the existing documentation style, and the documentation builds successfully with Sphinx without warnings.

No functional code changes were made — this PR only improves the user documentation to better reflect the existing UI behavior.

### Additional Action Required

Other than merging your change, do you want / need us to do anything else with your change? This could include reviewing a specific part of your PR.
