### PR TITLE
Use triple rather than pair for three element index entry

### DIFF
--- a/config/options_player.rst
+++ b/config/options_player.rst
@@ -1,7 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
-:index:`Audio Player Options <pair: configuration; audio player; listenbrainz>`
-===============================================================================
+:index:`Audio Player Options <triple: configuration; audio player; listenbrainz>`
+=================================================================================
 
 .. only:: not latex
 


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

The use of `pair:` with a three-element index item was not creating all three links in the PDF generated index.  See "pair" and "triple" in https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup


### Description of the Change

Change `pair:` to `triple:` in the `index` directive.


### AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the documentation or code were developed using AI and/or how was AI used in preparing this PR?
-->


### Additional Action Required

Other than merging your change, do you want / need us to do anything else with your change? This could include reviewing a specific part of your PR.
