### PR TITLE
Add `_iswc` variable

### DIFF
--- a/variables/variables_advanced.rst
+++ b/variables/variables_advanced.rst
@@ -89,6 +89,10 @@ If you enable tagging with :doc:`Use track relationships <../config/options_meta
 
    The date the recording was broadcast.
 
+**_iswc**
+
+   The International Standard Musical Work Code (ISWC) for the work. ISWC is a unique, permanent and internationally recognised reference number for the identification of musical works. It identifies a musical work as a unique intangible creation. It relates to the result of an intangible creation of one or more people, regardless of copyright status, distributions or agreements that cover this creation. (*since Picard 3.0*)
+
 **_lyricistsort**
 
    The sort names of the lyricists for the work. (*since Picard 2.9*)


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

A new `%_iswc%` variable is added in https://github.com/metabrainz/picard/pull/3160


### Description of the Change

Add documentation for the new variable.


### AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

### Additional Action Required

After merge, the translations files need to be updated.
