### PR TITLE
Add note regarding use of `plugin_development` debug log option

### DIFF
--- a/appendices/command_line.rst
+++ b/appendices/command_line.rst
@@ -33,13 +33,21 @@ where the options are:
 
    .. note::
 
-      The ``plugin_development`` debug option has been specifically designed to assist plugin developers by allowing detailed logging of plugin-related events that would not normally be included in the debug log. This can help developers identify issues and understand the behavior of their plugins within Picard. Debug log entries are useful when a user is trying to understand which plugin is making changes to metadata and such, but extensive debug logging such as that required for troubleshooting a specific plugin can be overwhelming. If detailed debug logging is included in a plugin, it should be used with a blocking guard so that it is only logged when the ``plugin_development`` debug option is specified on the command line. For example:
+      The ``plugin_development`` debug option has been specifically designed to assist plugin developers by allowing detailed logging of plugin-related events that would not normally be included in the debug log. This can help developers identify issues and understand the behavior of their plugins within Picard. Debug log entries are useful when a user is trying to understand which plugin is making changes to metadata and such, but extensive debug logging such as that required for troubleshooting a specific plugin can be overwhelming. If detailed debug logging is included, it should be used with the ``api.logger.debug_if()`` method so that it is only logged when the ``plugin_development`` debug option is specified on the command line. For example:
 
       .. code-block:: python
 
-         # Block guard to avoid extensive debug logging when disabled
+         # Single message
+         self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Detailed debug message with no parameters")
+         self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Resize: %d x %d", width, height)
+
+         # Lazy formatting with msg_func
+         self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, msg_func=lambda: "Settings: %s" % expensive())
+
+         # Block guard to skip expensive code entirely when disabled
          if dbg := self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
-             dbg("Detailed debug output for plugin development")
+             for item in items:
+                 dbg("item: %r", item)
 
 .. option:: -e COMMAND, --exec COMMAND
 

--- a/appendices/command_line.rst
+++ b/appendices/command_line.rst
@@ -31,6 +31,16 @@ where the options are:
 
    comma-separated list of debug options. Use --debug-opts without value to list available options
 
+   .. note::
+
+      The ``plugin_development`` debug option has been specifically designed to assist plugin developers by allowing detailed logging of plugin-related events that would not normally be included in the debug log. This can help developers identify issues and understand the behavior of their plugins within Picard. Debug log entries are useful when a user is trying to understand which plugin is making changes to metadata and such, but extensive debug logging such as that required for troubleshooting a specific plugin can be overwhelming. If detailed debug logging is included in a plugin, it should be used with a blocking guard so that it is only logged when the ``plugin_development`` debug option is specified on the command line. For example:
+
+      .. code-block:: python
+
+         # Block guard to avoid extensive debug logging when disabled
+         if dbg := self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
+             dbg("Detailed debug output for plugin development")
+
 .. option:: -e COMMAND, --exec COMMAND
 
    execute one or more COMMANDs at start-up (see :doc:`../usage/exec_commands` for more information)


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

A new debug logging option is being added in https://github.com/metabrainz/picard/pull/3172 and it was requested that this be documented for plugin developers.


### Description of the Change

Add documentation for the new option's use as it relates to extensive debug logging for plugins.


### AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)


### Additional Action Required

Once merged, the translation files need to be updated.
