### PR TITLE
PICARD-3362: Add "cluster" to glossary

### DIFF
--- a/about_picard/glossary.rst
+++ b/about_picard/glossary.rst
@@ -51,7 +51,7 @@ Many of the terms used in this documentation and within Picard itself have speci
 
    A :index:`cluster` is a group of audio files that belong to the same album.
 
-   When audio files are added to Picard for processing, either via the :guilabel:`Add Files...` button, :guilabel:`Add Folder...` button, or by dragging them into the main window, they are initially added to the "Unclustered Files" section in the Clustering pane. From there they can be grouped into clusters, either automatically by Picard based on existing metadata in the files, or manually by the user. Clusters can be used to identify releases to retrieve from the MusicBrainz database, and quickly match audio files to releases in the Albums pane.
+   When audio files are added to Picard for processing, either via the :guilabel:`Add Files...` button, :guilabel:`Add Folder...` button, or by dragging them into the main window, they are initially added to the "Unclustered Files" section in the Clustering pane. From there they can be grouped into clusters automatically by Picard based on existing metadata in the files. Clusters can be used to identify releases to retrieve from the MusicBrainz database, and quickly match audio files to releases in the Albums pane.
 
    Please see the :doc:`../usage/retrieve_lookup` page for additional information regarding creating and using clusters.
 

--- a/about_picard/glossary.rst
+++ b/about_picard/glossary.rst
@@ -47,6 +47,14 @@ Many of the terms used in this documentation and within Picard itself have speci
 
    Please see the `Cover Art Archive page <https://musicbrainz.org/doc/Cover_Art_Archive>`_ on the MusicBrainz website for additional information.
 
+**cluster**
+
+   A :index:`cluster` is a group of audio files that belong to the same album.
+
+   When audio files are added to Picard for processing, either via the :guilabel:`Add Files...` button, :guilabel:`Add Folder...` button, or by dragging them into the main window, they are initially added to the "Unclustered Files" section in the Clustering pane. From there they can be grouped into clusters, either automatically by Picard based on existing metadata in the files, or manually by the user. Clusters can be used to identify releases to retrieve from the MusicBrainz database, and quickly match audio files to releases in the Albums pane.
+
+   Please see the :doc:`../usage/retrieve_lookup` page for additional information regarding creating and using clusters.
+
 **disc id**
 
    A :index:`Disc ID <disc id>` is the code number which MusicBrainz uses to link a physical CD to a release listing. It is a string of letters, like ``XzPS7vW.HPHsYemQh0HBUGr8vuU-``. Disc IDs for a release can be seen on the disc IDs tab for the release on MusicBrainz. Clicking on these will give a detailed display of the disc ID, including the list of attached releases.


### PR DESCRIPTION

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

This was requested by Elektronika in the Community Forums:  https://community.metabrainz.org/t/suggestion-add-clustered-and-unclustered-to-glossary-of-terms/815396

> I suggest adding “Clustered” and “Unclustered” to the Glossary of Terms in the user documentation.


### Description of the Change

Add "cluster" to the definitions in the glossary.


### AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the documentation or code were developed using AI and/or how was AI used in preparing this PR?
-->


### Additional Action Required

Other than merging your change, do you want / need us to do anything else with your change? This could include reviewing a specific part of your PR.
