### PR TITLE
Add note about ISRCs from CDs not supported on some platforms

### DIFF
--- a/config/options_cdlookup.rst
+++ b/config/options_cdlookup.rst
@@ -16,7 +16,7 @@ This section allows you to select which CD ROM device to use by default for look
       :width: 75%
       :align: center
 
-When the "Read ISRCs from CD" option is enabled, ISRCs will be read from the CD during the disc lookup. The ISRCs will be added to the file metadata when the CD is read, and will be used when looking up releases on MusicBrainz.
+When the "Read ISRCs from CD" option is enabled, ISRCs will be read from the CD during the disc lookup. The ISRCs will be added to the file metadata when the CD is read, and will be used when looking up releases on MusicBrainz. Note that the code library used does not support reading ISRCs from CDs on some operating system platforms, so this option will not be available on those platforms. The three main platforms (Windows, Linux, and macOS) are supported.
 
 .. warning::
 
@@ -48,3 +48,5 @@ Platform-specific details
 **Other platforms:**
 
    On other platforms, the CD Lookup option is a text field and you should enter the path to the CD drive here.
+
+   Note that the code library used does not support reading ISRCs from CDs on some operating system platforms, so this option will not be available on those platforms.


### PR DESCRIPTION
### Summary

This is a…

- [x] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

Extracting ISRCs from CDs is not supported on all operating system platforms.


### Description of the Change

Add a note about possible unsupported platforms.


### AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the documentation or code were developed using AI and/or how was AI used in preparing this PR?
-->


### Additional Action Required

Update translation files.
