### PR TITLE
Add new script functions `$get_new()` and `$get_original()`

### DIFF
--- a/functions/alpha_list.txt
+++ b/functions/alpha_list.txt
@@ -22,6 +22,8 @@ func_firstalphachar
 func_firstwords
 func_foreach
 func_get
+func_get_new
+func_get_original
 func_getmulti
 func_gt
 func_gte

--- a/functions/cat_list.txt
+++ b/functions/cat_list.txt
@@ -135,6 +135,8 @@ Text Functions
    func_firstalphachar
    func_firstwords
    func_get
+   func_get_new
+   func_get_original
    func_initials
    func_left
    func_len

--- a/functions/func_get_new.rst
+++ b/functions/func_get_new.rst
@@ -1,0 +1,27 @@
+.. MusicBrainz Picard Documentation Project
+
+.. _func_get_new:
+
+$get_new
+========
+
+| Usage: **$get_new(name)**
+| Category: text
+| Implemented: Picard 3.0
+
+**Description:**
+
+Returns the value from new metadata only for the variable ``name`` or an empty string if ``name`` has not been set. If ``name`` is another variable (e.g. ``%indirect%``) the value of the variable will be used as ``name``. This allows the retrieval of dynamically named variables.
+
+.. note::
+
+   Usually you can access the values of a tag by the proper variable name. For example, if your tag is called "rerecorded" you can use ``%rerecorded%``. But the hyphen is not a valid character for a script variable, so ``%re-recorded%`` gives a syntax error. In cases like this you need to use ``$get_new(re-recorded)``.
+
+**Example:**
+
+Assuming that the original value of the tag `foo` is "bar" and the new value is "baz", the following statements will return the values indicated:
+
+.. code-block:: taggerscript
+
+   $get_new(foo)          ==>  "baz"
+   $get_original(foo)     ==>  "bar"

--- a/functions/func_get_original.rst
+++ b/functions/func_get_original.rst
@@ -1,0 +1,27 @@
+.. MusicBrainz Picard Documentation Project
+
+.. _func_get_original:
+
+$get_original
+=============
+
+| Usage: **$get_original(name)**
+| Category: text
+| Implemented: Picard 3.0
+
+**Description:**
+
+Returns the value from original metadata only for the variable ``name`` or an empty string if ``name`` has not been set. If ``name`` is another variable (e.g. ``%indirect%``) the value of the variable will be used as ``name``. This allows the retrieval of dynamically named variables.
+
+.. note::
+
+   Usually you can access the values of a tag by the proper variable name. For example, if your tag is called "rerecorded" you can use ``%rerecorded%``. But the hyphen is not a valid character for a script variable, so ``%re-recorded%`` gives a syntax error. In cases like this you need to use ``$get(re-recorded)``.
+
+**Example:**
+
+Assuming that the original value of the tag `foo` is "bar" and the new value is "baz", the following statements will return the values indicated:
+
+.. code-block:: taggerscript
+
+   $get_new(foo)          ==>  "baz"
+   $get_original(foo)     ==>  "bar"

--- a/functions/list_by_type.rst
+++ b/functions/list_by_type.rst
@@ -51,6 +51,8 @@ These functions are used to manage text (e.g.: extract, replace or format) in ta
       func_firstalphachar
       func_firstwords
       func_get
+      func_get_new
+      func_get_original
       func_initials
       func_left
       func_len
@@ -77,6 +79,8 @@ These functions are used to manage text (e.g.: extract, replace or format) in ta
    | :doc:`func_firstalphachar`
    | :doc:`func_firstwords`
    | :doc:`func_get`
+   | :doc:`func_get_new`
+   | :doc:`func_get_original`
    | :doc:`func_initials`
    | :doc:`func_left`
    | :doc:`func_len`


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

Two new scripting functions were added to Picard in https://github.com/metabrainz/picard/pull/3337.


### Description of the Change

Add new script functions `$get_new()` and `$get_original()` to the documentation.


### AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)


### Additional Action Required

Update translation files.
