### PR TITLE
Improve CI, pre-commit hooks, and build system

### DIFF
--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -58,9 +58,7 @@ jobs:
       run: python ./dev_utils.py test rst
     - name: Setup for Build
       run: |
-        export SPHINXBUILD=`which sphinx-build`
         mkdir _build
-        mkdir docs
     - name: Build Tag Map Files
       run: |
         python ./dev_utils.py build map

--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -49,6 +49,7 @@ jobs:
       uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/manual_check_and_build.yml
+++ b/.github/workflows/manual_check_and_build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python ${{ inputs.pythonVersion }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/manual_check_and_build.yml
+++ b/.github/workflows/manual_check_and_build.yml
@@ -6,12 +6,12 @@ on:
       pythonVersion:
         description: 'Python version to use for the processing'
         required: true
-        default: '3.11'
+        default: '3.14'
         type: choice
         options:
-          - 3.11
           - 3.12
           - 3.13
+          - 3.14
 
 jobs:
   lint_rst_and_basic_build:

--- a/.github/workflows/manual_check_and_build.yml
+++ b/.github/workflows/manual_check_and_build.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r requirements_dev.txt
     - name: Lint Test RST Files
       run: python ./dev_utils.py test rst
     - name: Setup for Build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,4 @@ repos:
       entry: python dev_utils.py test rst
       language: system
       pass_filenames: false
-      types: [ text ]
+      types: [ rst ]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,7 @@ sphinx:
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
-  # fail_on_warning: true
+   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/conf.py
+++ b/conf.py
@@ -87,6 +87,7 @@ exclude_patterns = [
     '_locale',
     '_project_documentation',
     '__pycache__',
+    '.venv',
     'Thumbs.db',
     '.DS_Store',
     'html',

--- a/dev_utils.py
+++ b/dev_utils.py
@@ -692,7 +692,9 @@ class LintRST():    # pylint: disable=too-many-instance-attributes
         Returns:
             {int} -- Error code 1 if check failed, otherwise 0.
         """
-        for dir_name, _subdir_list, file_list in os.walk(root_dir):
+        skip_dirs = {'.venv', '.git', '_build', '__pycache__', 'node_modules'}
+        for dir_name, subdir_list, file_list in os.walk(root_dir):
+            subdir_list[:] = [d for d in subdir_list if d not in skip_dirs]
             for fname in file_list:
                 if str(fname).lower().endswith('.rst'):
                     self.check_file(os.path.join(dir_name, fname))

--- a/dev_utils.py
+++ b/dev_utils.py
@@ -317,8 +317,8 @@ class SPHINX_():        # pylint: disable=too-few-public-methods
     GETTEXT_DIR = os.path.join(LOCALE_DIR, 'gettext')
     BUILD_TIMEOUT = 300
     BUILD_TARGETS = {
-        'html': {'dir': 'html', 'cmd': 'html', 'extra': ''},
-        'pdf': {'dir': 'latex', 'cmd': 'latex', 'extra': ''},
+        'html': {'dir': 'html', 'cmd': 'html', 'extra': '-W --keep-going'},
+        'pdf': {'dir': 'latex', 'cmd': 'latex', 'extra': '-W --keep-going'},
     }
 
 

--- a/pdf_build.sh
+++ b/pdf_build.sh
@@ -9,7 +9,7 @@ printenv
 
 echo ""
 echo "Build LaTeX files"
-sphinx-build -M latex . _build -D language=$READTHEDOCS_LANGUAGE
+sphinx-build -M latex . _build -W --keep-going -D language=$READTHEDOCS_LANGUAGE
 
 echo ""
 echo "List output files"


### PR DESCRIPTION
## Summary

This is a…
- Correction
- Restructuring
- Minor / simple change (like a typo)

## Reason for the Change

The CI and build system had several issues:
- RST lint was scanning `.venv` causing false positives from installed packages
- Sphinx build warnings passed silently (no `-W` flag)
- ReadTheDocs and PDF builds didn't fail on warnings either
- Pre-commit local hook triggered on all text files instead of just RST
- Dead code in CI workflow (unused `export SPHINXBUILD`, `mkdir docs`)
- Manual workflow missing `requirements_dev.txt` and had stale Python versions
- No pip caching in CI
- Unnecessary full git history checkout

## Description of the Change

10 focused commits, each addressing one issue:

1. Exclude `.venv` and other non-project dirs from RST lint walk
2. Add `-W --keep-going` to Sphinx builds (warnings as errors)
3. Fix pre-commit local hook: `types: [text]` → `types: [rst]`
4. Enable `fail_on_warning: true` in ReadTheDocs config
5. Remove dead `mkdir docs` and `export SPHINXBUILD` from CI
6. Add `-W --keep-going` to `pdf_build.sh`
7. Add `cache: 'pip'` to CI setup-python
8. Update manual workflow Python versions to 3.12-3.14
9. Install `requirements_dev.txt` in manual workflow
10. Reduce `fetch-depth` to 1 in both workflows

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:
- Significant use (e.g. code structure, tests development, etc.)

Analysis, implementation, and commit messages developed with AI assistance (Kiro CLI). All decisions reviewed and directed by the developer.

## Additional Action Required

None. Verified locally and via manual workflow dispatch on fork (run #3, succeeded in 4m 52s).