### PR TITLE
PICARD-3215: Add documentation for iTunes CDDB lookup

### DIFF
--- a/usage/retrieve.rst
+++ b/usage/retrieve.rst
@@ -26,6 +26,25 @@ This is the preferred method of automatically identifying the album to retrieve,
    .. include:: retrieve_lookup_cd.rst
 
 
+.. only:: latex
+
+   Lookup iTunes Tag
+   ------------------
+
+.. only:: html
+
+   :doc:`Lookup iTunes Tag <retrieve_lookup_itunes>`
+   --------------------------------------------------
+
+If your files contain the "iTunes CDDB 1" tag (``itunes_cddb_1``), then you can perform the lookup using this information. This tag contains the number of tracks and track lengths for the album providing the track. This is similar to the TOC information used in the "Lookup CD or Ripper Log" method.
+
+When initiated, the information from the tag is used to calculate a TOC signature. A request is sent to MusicBrainz to return a list of the releases that match the TOC. If there are any matches, then they will be listed for you to select the one to use. If there are no matches or none of the matches are correct, you can search the database manually for the matching album.
+
+.. only:: latex
+
+   .. include:: retrieve_lookup_itunes.rst
+
+
 .. _ref_lookup_files:
 
 .. only:: latex
@@ -104,6 +123,7 @@ The second browser search method uses manually entered information as the search
 
       Step-by-step instructions:
       :doc:`retrieve_lookup_cd` /
+      :doc:`retrieve_lookup_itunes` /
       :doc:`retrieve_lookup` /
       :doc:`retrieve_scan` /
       :doc:`retrieve_browser` /

--- a/usage/retrieve_lookup_itunes.rst
+++ b/usage/retrieve_lookup_itunes.rst
@@ -1,0 +1,37 @@
+.. MusicBrainz Picard Documentation Project
+
+Lookup iTunes Tag
+=================
+
+The steps to follow to :index:`lookup an iTunes Tag <lookup; iTunes>` are:
+
+Step 1
+-------
+
+Select the files or cluster that you want to look up, and select :menuselection:`"Tools --> Lookup CD... --> Lookup TOC tag..."`. Picard will try to get the album TOC information from the ``itunes_cddb_1`` tag in each file to use to query the MusicBrainz database and display a list of matching releases. If there are no ``itunes_cddb_1`` tags found, then an error message will be displayed.
+
+.. image:: images/cd_lookup_1.png
+   :align: center
+
+.. only:: not latex
+
+   |
+
+Step 2
+-------
+
+Select the correct release from the list and click on the :guilabel:`Load into Picard` button. This will load the information for the release into Picard.
+
+A music symbol in front of a track number in the right-hand pane indicates that there has been no file assigned to the track.
+
+.. image:: images/cd_lookup_result.png
+   :align: center
+
+.. only:: not latex
+
+   |
+
+Step 3
+-------
+
+If there are no matches or none of the matches are correct, you will have to use one of the other methods such as :doc:`Cluster and Lookup <retrieve_lookup>`, :doc:`retrieve_browser` or :doc:`retrieve_manual`.


### PR DESCRIPTION

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other


### Reason for the Change

The CD lookup menu has been restructured in https://github.com/metabrainz/picard/pull/3049 and this need to be updated in the documentation. The new functionality added in https://github.com/metabrainz/picard/pull/3046 should also be added to the documentation.


### Description of the Change

Add the new information to the documentation.  Note that the new tag information has already been added in a separate PR.

### AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)


### Additional Action Required

Update translation files.
